### PR TITLE
curry L/CF improvements

### DIFF
--- a/docs/spinsystem.html
+++ b/docs/spinsystem.html
@@ -120,7 +120,7 @@ The following groups of parameters can be specified in the spin system structure
 <li><a href = "#B">Higher-order operators</a></li>
 <li><a href = "#ee">Electron-electron spin-spin couplings</a></li>
 <li><a href = "#nn">Nuclear-nuclear spin-spin couplings</a></li>
-<li><a href = "#soi">Spin-orbit interaction</a></li>
+<li><a href = "#soi">Orbital angular momenta and spin-orbit interaction</a></li>
 <li><a href = "#Ham">General Paramters for Spin Hamiltonian expanded in Magnetic Field and Electron Spin</a></li>
 <li><a href = "#lw">Broadenings</a></li>
 </ul>
@@ -1092,18 +1092,28 @@ This is fully analogous to <code>eeFrame</code> (see above). Check out the page 
 </div>
 
 
-<div class="subtitle"><a name="soi">Spin-orbit interaction</a></div>
-For each electron spin an orbital angular momentum can be defined in the field <code>L</code>. It is described by the crystal field splitting, the orbital reduction factor and the spin-orbit coupling. Currently, spin-orbit interaction is supported by the simulation functions <a class="esf" href="pepper.html">pepper</a> (solid-state EPR)and <a class="esf" href="curry.html">curry</a>. 
-<p> Please cite Joscha and friends <em>Journal of unsolved questions</em>, <b>2020</b>, 87, 92-109 when using spin-orbit interaction.
+<div class="subtitle"><a name="soi">Orbital angular momenta and spin-orbit interaction</a></div>
+Each electron spin in the spin system can be coupled to an orbital angular momentum, with the assocaited quantum number defined in the field <code>L</code>. Spin-orbit coupling is specified via the fields <code>soc</code> (coupling strength) and <code>orf</code> (orbital reduction factor). Orbital angular momenta are supported by the simulation functions <a class="esf" href="pepper.html">pepper</a> (solid-state EPR) and <a class="esf" href="curry.html">curry</a> (magnetometry).
+
 <p>
 <div class="optionfield"><code>L</code></div>
 <div class="optiondescr">
-Defines the orbital angular momenta to which the electron spins should be coupled. <code>L</code> is an optional field. If given it need to have the same number of entries as <code>S</code> and the entries have to be positive integer or 0. Examples:
+Gives the quantum numbers for orbital angular momenta to which the electron spins are coupled. <code>L</code> is an optional field. If given, it must have the same number of entries as <code>S</code> and the entries have to be nonnegative integers. The kth orbital angular momentum is coupled to the kth spin angular momentum. Examples:
+
 <pre class="matlab">
-Sys = struct('S',[1/2 1/2], 'L',[2,2]); % two spin-1/2, each associated to L = 2
-Sys = struct('S',[1/2 3/2], 'L',[0,1]); % one spin-1/2 without L and a spin 3/2 with L = 1
-Sys = struct('S',1, 'L',3);             % one spin 1 associated to a L = 3
+% one spin 1 associated to a L = 3
+Sys.S = 1;
+Sys.L = 3;
+
+% two spin-1/2, each associated to L = 2
+Sys.S = [1/2 1/2];
+Sys.L = [2 2];
+
+% one spin-1/2 without L and a spin 3/2 with L = 1
+Sys.S = [1/2 3/2];
+Sys.L = [0 1];
 </pre>
+
 </div>
 <div class="optionfield"><code>CF0, CF2, CF4, CF6, CF8, CF10, CF12</code></div>
 <div class="optiondescr">
@@ -1158,27 +1168,29 @@ Sys.CF2 = CF2.';
 
 <div class="optionfield"><code>orf</code></div>  
 <div class="optiondescr">
-Orbital reduction factor entering in the Zeeman Hamiltonian and the spin-orbit interaction for each orbital angular momentum. <code>orf</code> is an optional field, if omitted it is assumed as 1 for all orbital angular momenta. The number of elements in <code>orf</code> has to match the number of elements in <code>L</code>.
+Orbital reduction factors (orf) entering in the Zeeman Hamiltonian and the spin-orbit interaction, one for each orbital angular momentum in <code>L</code>. <code>orf</code> is an optional field, if omitted it is assumed equal to 1 for all orbital angular momenta. The number of elements in <code>orf</code> must match the number of elements in <code>L</code>.
 
 <pre class="matlab">
-Sys.orf = 3/2;          % orf of a single effective l =1 as calculated by Lines for octahedral Co(II)
-Sys.orf = [0.97, 0.93]; % orf for two orbital angular momenta
+Sys.orf = 3/2;          % orf for a single orbital angular momentum
+Sys.orf = [0.97 0.93];  % orf for two orbital angular momenta
 </pre>
 </div>
 
 <div class="optionfield"><code>soc</code></div>  
 <div class="optiondescr">
-Spin-orbit coupling in MHz. It can also contain higher orders of the spin-orbit coupling, as sometimes used for heavier elements. Each electron spin can only be coupled to one orbital angular momentum. If more than one electron is present, the first row contain the coupling between the first electron spin and the first orbital angular momentum and so on. Examples:
+Spin-orbit coupling constants, in MHz. It can also contain higher orders of the spin-orbit coupling, as sometimes used for heavier elements. Each electron spin can only be coupled to one orbital angular momentum. If more than one electron is present, the first row contain the coupling between the first electron spin and the first orbital angular momentum and so on. Examples:
 <pre class="matlab">
-% three electron spins, with linear soc parameter of 170, 250 cm-1 and 0:
+% three electron spins, with linear soc parameter of 170, 250 cm^-1 and 0:
 Sys.soc = [170; 250; 0]*clight*1e-4;
-% as above, plus the first spin has a cubic soc parameter of 10 cm-1:
+% as above, plus the first spin has a cubic soc parameter of 10 cm-^1:
 Sys.soc = [170 0, 10; 250, 0, 0; 0, 0, 0]*clight*1e-4; 
 
-Sys = struct('S',[1/2 1], 'L',[2,1]); % two electron spin with S =1/2 and 1 and L = 2 and 1
+% two electron spin with S =1/2 and 1 and L = 2 and 1
+Sys.S = [1/2 1];
+Sys.L = [2 1];
 Sys.soc = [200; 100]*clight*1e-4; 
-% linear soc parameter between S = 1/2 and L = 2 is 200 cm-1
-% linear soc parameter between S = 1 and L = 1 is 100 cm-1
+% linear soc of 200 cm-1 between S = 1/2 and L = 2 
+% linear soc of 100 cm-1 parameter between S = 1 and L = 1
 </pre>  
 </div>
 

--- a/easyspin/private/validatespinsys.m
+++ b/easyspin/private/validatespinsys.m
@@ -1024,7 +1024,7 @@ if isfield(Sys,'L') && ~isempty(Sys.L)
         ' instead of ', num2str(2*k+1),' coloumns.'];
     end
     Sys.(fieldname) = CFk; 
-  end  
+  end
 else
   if isfield(Sys,'orf') && ~isempty(Sys.orf)
     error('Sys.orf is given, but Sys.L is missing. Specify Sys.L.');
@@ -1041,17 +1041,14 @@ else
   Sys.L = [];
   Sys.orf = [];
 end
-  
-  
-
-
+Sys.nL = numel(Sys.L);
 
 %--------------------------------------------------------------------------
 Sys.Spins = [Sys.S(:); Sys.I(:); Sys.L(:)].';
 Sys.nStates = hsdim(Sys.Spins);
 
 FullSys = Sys;
-FullSys.processed = 1;
+FullSys.processed = true;
 
 return
 %@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@

--- a/easyspin/soint.m
+++ b/easyspin/soint.m
@@ -15,17 +15,17 @@
 %       for which the SOI should be computed. If
 %       absent, all electrons are included.
 %   - 'sparse': If given, the matrix is returned in sparse format.
-
+%
 %   Output:
 %   - H: Hamiltonian matrix containing the SOI for
 %        spins specified in eSpins.
 
 function H = soint(System,Spins,opt)
 
-if (nargin==0), help(mfilename); return; end
+if nargin==0, help(mfilename); return; end
 
-if (nargin<1) || (nargin>3), error('Wrong number of input arguments!'); end
-if (nargout>1), error('Too many output arguments.'); end
+if nargin<1 || nargin>3, error('Wrong number of input arguments!'); end
+if nargout>1, error('Too many output arguments.'); end
 
 if nargin<3, opt = ''; end
 if nargin<2, Spins = []; end
@@ -37,17 +37,14 @@ sparseResult = strcmp(opt,'sparse');
 [System,err] = validatespinsys(System);
 error(err);
 
-shift = System.nElectrons+System.nNuclei;
-
-% Special cases: no OAM, soc not given or all zero
+% Special cases: no orbital angular momemta L, or .soc not given or all zero
 H = sparse(System.nStates,System.nStates);
-if (numel(System.Spins)== shift) || ~any(System.soc(:))
+if System.nL==0 || all(System.soc(:)==0)
   if ~sparseResult
     H = full(H); % sparse -> full
   end
-  return;
+  return
 end
-
 
 if isempty(Spins), Spins = 1:System.nElectrons; end
 
@@ -62,31 +59,29 @@ if numel(unique(Spins))~=numel(Spins)
   error('Spins (2nd argument) contains double entries!');
 end
 
-% Compile list of wanted interactions
-nPairs = length(Spins);
 
-% Compile list of all spin pairs
-
-% Bilinear coupling term S1*ee*S2
+% Spin-orbit coupling terms sop*S(k)*L(k)
 %----------------------------------------------------------------
-for k = 1:nPairs
-  if any(System.soc(Spins(k)))
-    % Sum up Hamiltonian terms
-    F = sparse(System.nStates,System.nStates);
-    for c1 = 1:3
-      %spin operator
-      so = sop(System,[Spins(k),Spins(k)+shift],c1,'sparse');
-      F = F + so;
-    end
-    for n=1:length(System.soc(Spins(k),:))
-      H = H + System.soc(Spins(k),n)* (System.orf(Spins(k))*F)^n;
-    end;
+shift = System.nElectrons + System.nNuclei;
+for k = 1:length(Spins)
+  
+  iSpin = Spins(k);
+  soc_ = System.soc(iSpin,:);
+  if ~any(soc_), continue; end
+  
+  % Build S*L operator matrix
+  SL = sparse(System.nStates,System.nStates);
+  for c1 = 1:3
+    SL = SL + sop(System,[iSpin,iSpin+shift],c1,'sparse');
+  end
+  
+  % Add SOC terms to Hamiltonian
+  for order = find(soc_)
+    H = H + soc_(order) * (System.orf(iSpin)*SL)^order;
   end
   
 end
 
-
-H = (H+H')/2; % Hermitianise
 if ~sparseResult
   H = full(H); % sparse -> full
 end

--- a/easyspin/stev.m
+++ b/easyspin/stev.m
@@ -128,7 +128,7 @@ if mod(k,1) || (k<0) || (k>kmax) || ~isreal(k)
   error('k too large. Maximum supported k is %d.',kmax);
 end
 if (k>2*S)
-  error('k must not be larger than 2*S (%d with S=%g).',2*S,S);
+  error('Stevens operator with k=%d given. k must not be larger than 2*S (%d with S=%g).',k,2*S,S);
 end
 if mod(q,1) || abs(q)>k || ~isreal(q)
   error('q must be an integer between -k and k (%d and %d).',-k,k);

--- a/easyspin/zeeman.m
+++ b/easyspin/zeeman.m
@@ -98,7 +98,8 @@ lFactor = -bmagn/(planck*1e9)*Sys.orf;
 % Loop over all spins selected
 for idx = 1:numel(Spins)
   iSpin = Spins(idx);
-  if iSpin<=nElectrons   % If it's an electron...
+  if iSpin<=nElectrons
+    % If it's an electron...
     if Sys.fullg
       g = elFactor((iSpin-1)*3+(1:3),:);
     else
@@ -124,7 +125,7 @@ for idx = 1:numel(Spins)
     ZyM = ZyM + pre*sop(SpinVec,iSpin,2,'sparse');
     ZzM = ZzM + pre*sop(SpinVec,iSpin,3,'sparse');
   else
-    % orbital angular momentum, isotropic
+    % Orbital angular momenta, isotropic
     % Build orbital Zeeman Hamiltonian in MHz/mT
     pre = lFactor(iSpin-nEN);
     ZxM = ZxM + pre*sop(SpinVec,iSpin,1,'sparse');

--- a/tests/zeeman_oam.m
+++ b/tests/zeeman_oam.m
@@ -1,25 +1,35 @@
 function [err,data] = test(opt,olddata)
-%orbital angular momenta can also be defined as spins, therefore the two
-%Hamiltonians should be identical
+
+% Orbital angular momenta can also be defined as spins, therefore the two
+% Hamiltonians should be identical.
+
 rng_(5,'twister');
 
 n = randi_(3);
-Sys.S = randi_(3,1,n)/2;
-Sys.L = randi_(3,1,n);
-Sys.soc = zeros(n,1);
-Sys.g = rand(3*n,3);
-Sys.orf = rand(n, 1);
-if n>1, Sys.ee = zeros(nchoosek(length(Sys.S),2),1);end
-PureSpin.S = [Sys.S,Sys.L];
-PureSpin.ee = zeros(nchoosek(length([Sys.S,Sys.L]),2),1);
-PureSpin.g = [Sys.g;zeros(3*n,3)];
-for k=1:n
-  PureSpin.g(3*(n+k-1)+1:3*(n+k),:) = -diag(Sys.orf(k)*ones(1,3));
+S = randi_(3,1,n)/2;
+L = randi_(3,1,n);
+
+% System with S and L
+SysSL.S = S;
+SysSL.L = L;
+SysSL.soc = zeros(n,1);
+SysSL.g = rand(3*n,3);
+SysSL.orf = rand(n, 1);
+if n>1
+  SysSL.ee = zeros(nchoosek(length(SysSL.S),2),1);
 end
 
+% System with [S L]
+PureSpin.S = [SysSL.S,SysSL.L];
+PureSpin.ee = zeros(nchoosek(length([SysSL.S,SysSL.L]),2),1);
+PureSpin.g = [SysSL.g; zeros(3*n,3)];
+for k = 1:n
+  PureSpin.g(3*(n+k-1)+1:3*(n+k),:) = -diag(SysSL.orf(k)*ones(1,3));
+end
 
+% Compare Hamiltonians
 H1 = zfield(PureSpin);
-H2 = crystalfield(Sys);
+H2 = crystalfield(SysSL);
 
 err = ~areequal(H1,H2,1e-10,'abs');
 data = [];


### PR DESCRIPTION
Fix a few bugs that result in incorrect output of `curry` if `Sys.CF*` , `Sys.L`, `Sys.soc`, etc are given