### PR TITLE
estest: fixed bug in coverage analysis

### DIFF
--- a/tests/estest.m
+++ b/tests/estest.m
@@ -248,12 +248,17 @@ if runCodeCoverageAnalysis
     if isempty(RunnableLines)
       RunnableLines = 0;
     end
-    TotalRunnable = TotalRunnable + length(unique(RunnableLines));
     Executed = unique(executedLines{n});
     Covered = length(Executed);
     TotalCovered = TotalCovered + Covered;
     Runnable = length(unique(RunnableLines));
     Code = fileread(FcnName);
+    % Account for lines missed by callstats
+    if Covered > Runnable
+        TotalRunnable = TotalRunnable + Covered;
+    else
+        TotalRunnable = TotalRunnable + Runnable;
+    end
     if params =='l'
       Missed = RunnableLines;
       for k=1:length(Executed)


### PR DESCRIPTION
In the code coverage analysis of ``estest``, the undocumented ``callstats`` function appears to miss or not consider runnable code lines with statements such as 
```` matlab
if nargin==0
...
end
````
which can lead to situations where some functions appear to have more covered lines than runnable, distorting the coverage results. 

Applied the same fix as in DeerLab's ``dltest``.