### PR TITLE
eprload not correctly loading files

### DIFF
--- a/easyspin/eprload.m
+++ b/easyspin/eprload.m
@@ -86,13 +86,13 @@ end
 [p,Name,FileExtension] = fileparts(FileName);
 FullBaseName = fullfile(p,Name);
 
-if isempty(FileExtension)
-  if exist([FullBaseName '.dta'],'file'), FileExtension = '.dta'; end
-  if exist([FullBaseName '.DTA'],'file'), FileExtension = '.DTA'; end
-  if exist([FullBaseName '.spc'],'file'), FileExtension = '.spc'; end
+if isempty(FileExtension) || length(FileExtension) < 2
+  if exist(join([FullBaseName '.dta'],''),'file'), FileExtension = '.dta'; end
+  if exist(join([FullBaseName '.DTA'],''),'file'), FileExtension = '.DTA'; end
+  if exist(join([FullBaseName '.spc'],''),'file'), FileExtension = '.spc'; end
 end
 
-FileName = [FullBaseName FileExtension];
+FileName = join([FullBaseName FileExtension],'');
 LocationType = exist(FileName,'file');
 if any(LocationType==[0 1 5 8]) % not a file/directory
   error('The file or directory %s does not exist!',FileName);

--- a/easyspin/private/eprload_BrukerBES3T.m
+++ b/easyspin/private/eprload_BrukerBES3T.m
@@ -142,7 +142,7 @@ if (numel(Abscissa)==1)
 end
 
 % Read data matrix.
-Data = getmatrix([FullBaseName,SpcExtension],Dimensions,NumberFormat,ByteOrder,isComplex);
+Data = getmatrix(join([FullBaseName,SpcExtension],''),Dimensions,NumberFormat,ByteOrder,isComplex);
 
 % Scale spectrum/spectra
 if ~isempty(Scaling)
@@ -243,6 +243,8 @@ function [Parameters,err] = readDSCfile(DSCFileName)
 
 Parameters = [];
 err = [];
+
+DSCFileName = join(DSCFileName,'');
 
 if exist(DSCFileName,'file')
   fh = fopen(DSCFileName);

--- a/easyspin/private/eprload_BrukerESP.m
+++ b/easyspin/private/eprload_BrukerESP.m
@@ -201,7 +201,7 @@ if ~TwoD && ny>1, ny = 1; end
 % Read data file.
 nz = 1;
 Dimensions = [nx ny nz];
-Data = getmatrix([FullBaseName,SpcExtension],Dimensions,NumberFormat,Endian,isComplex);
+Data = getmatrix(join([FullBaseName,SpcExtension],''),Dimensions,NumberFormat,Endian,isComplex);
 
 % Convert to a row vector in the case of 1D dataset
 if ny==1, Data = Data(:).'; end
@@ -281,6 +281,8 @@ function [Parameters,err] = eprload_readPARfile(PARFileName)
 
 Parameters = [];
 err = [];
+
+PARFileName = join(PARFileName,'');
 
 if exist(PARFileName,'file')
   fh = fopen(PARFileName);

--- a/tests/eprload_strings_and_characters.m
+++ b/tests/eprload_strings_and_characters.m
@@ -1,6 +1,6 @@
 function ok = test()
 
-FilePaths = {'./eprfiles/00012107','./eprfiles/00011201',"./eprfiles/00012107.dta","./eprfiles/00011201.spc"};
+FilePaths = {'./eprfiles/00012107','./eprfiles/00011201',"./eprfiles/00012107","./eprfiles/00012107.dta","./eprfiles/00011201","./eprfiles/00011201.spc"};
 
 try
   for i = 1 : length(FilePaths)

--- a/tests/eprload_strings_and_characters.m
+++ b/tests/eprload_strings_and_characters.m
@@ -1,0 +1,13 @@
+function ok = test()
+
+FilePaths = {'./eprfiles/00012107','./eprfiles/00011201',"./eprfiles/00012107.dta","./eprfiles/00011201.spc"};
+
+try
+  for i = 1 : length(FilePaths)
+    [~,~] = eprload(FilePaths{i});
+  end
+  ok = true;
+catch
+  ok = false;
+end
+


### PR DESCRIPTION
Apparently there was an update to how MATLAB processes string array when checking for or loading a file - see issue #197 for more details.

This PR should improve stability for newer version while keeping backwards compatibility.