### PR TITLE
docbuilder: replace rmdir with rd

### DIFF
--- a/docsrc/eulerangles.html
+++ b/docsrc/eulerangles.html
@@ -135,7 +135,7 @@ The <b>columns</b> of R contain the vector representations of x, y and z in the 
 </ul>
 
 <div class="eqn">
-  <img src="eqn/eulerangles2.png" alt="[eqn]"><!--MATH
+  <img src="eqn/eulerangles3.png" alt="[eqn]"><!--MATH
   \begin{equation*}
     R =
     \begin{pmatrix}
@@ -158,7 +158,7 @@ More generally, each of the elements or R is the scalar product of one of the AB
 </p>
 
 <div class="eqn">
-  <img src="eqn/eulerangles2.png" alt="[eqn]"><!--MATH
+  <img src="eqn/eulerangles4.png" alt="[eqn]"><!--MATH
   \begin{equation*}
     \newcommand{\scapr}[2]{\boldsymbol{#1}\cdot\boldsymbol{#2}}
     R =
@@ -178,7 +178,7 @@ axis, then by &beta; around the <em>original</em> y axis, and finally by &alpha;
 </p>
 
 <div class="eqn">
-<img src="eqn/eulerangles2.png" alt="[eqn]"><!--MATH
+<img src="eqn/eulerangles5.png" alt="[eqn]"><!--MATH
 \begin{equation*}
   R_\mr{z''}(\gamma)\cdot R_\mr{y'}(\beta)\cdot
   R_\mr{z}(\alpha)\\
@@ -197,7 +197,7 @@ use
 
 <div class="eqn">
 
-<img src="eqn/eulerangles3.png" alt="[eqn]"><!--MATH
+<img src="eqn/eulerangles6.png" alt="[eqn]"><!--MATH
 \begin{equation*}
 (\alpha_2,\beta_2,\gamma_2)
 =
@@ -207,19 +207,19 @@ use
 </div>
 
 <p>
-i.e., interchange <img src="eqn/eulerangles4.png" alt="[eqn]"><!--MATH$\alpha_1$--> and <img src="eqn/eulerangles5.png" alt="[eqn]"><!--MATH$\gamma_1$--> and
+i.e., interchange <img src="eqn/eulerangles7.png" alt="[eqn]"><!--MATH$\alpha_1$--> and <img src="eqn/eulerangles8.png" alt="[eqn]"><!--MATH$\gamma_1$--> and
 invert all the signs.
 </p>
 
 <div class="subtitle">Equivalent sets of Euler angles</div>
 
 <p>
-Of course, the addition to any angle of an arbitrary multiple of 2<img src="eqn/eulerangles6.png" alt="[eqn]"><!--MATH$\uppi$-->
+Of course, the addition to any angle of an arbitrary multiple of 2<img src="eqn/eulerangles9.png" alt="[eqn]"><!--MATH$\uppi$-->
 has no effect on the rotation matrix.
 </p>
 
 <div class="eqn">
-<img src="eqn/eulerangles7.png" alt="[eqn]"><!--MATH
+<img src="eqn/eulerangles10.png" alt="[eqn]"><!--MATH
 \begin{equation*}
 R(\alpha,\beta,\gamma)
 =
@@ -233,7 +233,7 @@ There are, however, other sets of Euler angles which give the same rotation matr
 </p>
 
 <div class="eqn">
-<img src="eqn/eulerangles8.png" alt="[eqn]"><!--MATH
+<img src="eqn/eulerangles11.png" alt="[eqn]"><!--MATH
 \begin{equation*}
 R(\alpha,\beta,\gamma)
 =
@@ -250,7 +250,7 @@ R(\alpha-\uppi,-\beta,\gamma-\uppi)
 
 <p>
 So, if you invert the sign of &beta;, you have to add
-(or subtract) <img src="eqn/eulerangles9.png" alt="[eqn]"><!--MATH$\uppi$--> to both &alpha; and &gamma;.
+(or subtract) <img src="eqn/eulerangles12.png" alt="[eqn]"><!--MATH$\uppi$--> to both &alpha; and &gamma;.
 </p>
 
 
@@ -260,7 +260,7 @@ and rotation matrices only if the Euler angle domains are restricted, e.g. to
 </p>
 
 <div class="eqn">
-<img src="eqn/eulerangles10.png" alt="[eqn]"><!--MATH
+<img src="eqn/eulerangles13.png" alt="[eqn]"><!--MATH
 \begin{equation*}
 0\le \alpha < 2\uppi
 \qquad

--- a/docsrc/hamiltonian.html
+++ b/docsrc/hamiltonian.html
@@ -667,10 +667,10 @@ nucleus. The EFG tensor is the matrix of all second derivatives of the electrost
 It is usually given in barn (1 barn = 10<sup>-28</sup> m<sup>2</sup> = 10<sup>-24</sup> cm<sup>2</sup>).
 
 <p>
-The nuclear quadrupole tensor is related to the EFG tensor <img src="eqn/hamiltonian55a.png" alt="[eqn]"><!--MATH$\mx{V}$--> via
+The nuclear quadrupole tensor is related to the EFG tensor <img src="eqn/hamiltonian57.png" alt="[eqn]"><!--MATH$\mx{V}$--> via
 
 <div class="eqn">
-<img src="eqn/hamiltonian54a.png" alt="[eqn]"><!--MATH
+<img src="eqn/hamiltonian58.png" alt="[eqn]"><!--MATH
 $$
 \mx{Q}
 =

--- a/releasing/docbuilder.pl
+++ b/releasing/docbuilder.pl
@@ -39,7 +39,7 @@ if (not -e $templatefile) {
 # check if documentation folder already exists and delete if yes
 if (-e $documentationdir) {
   if ($isWindows) {
-    system("rmdir /s /q $documentationdir ");
+    system("rd /s /q $documentationdir ");
   }
   else{
     system("rm -R $documentationdir");
@@ -49,7 +49,7 @@ if (-e $documentationdir) {
 # delete the temporary latex directory if it exists
 if (-e $tempdir) {
   if ($isWindows) {
-    system("rmdir /s /q $tempdir ");
+    system("rd /s /q $tempdir ");
   }
   else {
     system("rm -R $tempdir");
@@ -60,7 +60,7 @@ if (-e $tempdir) {
 $htmltemplatedir = File::Spec->catdir($documentationdir, "templates");
 if ($isWindows) {
     system("xcopy /E $sourcedir $documentationdir\\ > NUL"); # double slash \\ is required so that Windows understand it is a directory
-    system("rmdir /s /q $htmltemplatedir ");
+    system("rd /s /q $htmltemplatedir ");
   }
 else{
     system("cp -r $sourcedir $documentationdir");
@@ -118,9 +118,7 @@ foreach $htmlfile (@names) {
 
 
     if ($n_equations>0) {
-      print "=====================================================\n";
       print "  ".$htmlfile.":  ".$n_equations." latex expressions\n";
-      print "=====================================================\n";
       
       $latex = join("\n\\newpage\n",@latexcode);
 
@@ -192,7 +190,7 @@ foreach $htmlfile (@names) {
 
 if (-e "$tempdir") {
   if ($isWindows) {
-    system("rmdir /s /q $tempdir ");
+    system("rd /s /q $tempdir ");
   }
   else {
     system("rm -R $tempdir");


### PR DESCRIPTION
Fix problem with `rmdir` on my Windows system by using `rd` instead of `rmdir`.