### PR TITLE
bug fix for blochsteady (#210)

### DIFF
--- a/easyspin/blochsteady.m
+++ b/easyspin/blochsteady.m
@@ -59,7 +59,7 @@ EasySpinLogLevel = Options.Verbosity;
 logmsg(1,['=begin=blochsteady======' datestr(now) '=================']);
 
 if ~isfield(Options,'nPoints')
-  Options.nPoints = 1000;
+  Options.nPoints = [];
 end
 if ~isfield(Options,'Method')
   Options.Method = 'fft';

--- a/easyspin/blochsteady.m
+++ b/easyspin/blochsteady.m
@@ -124,7 +124,7 @@ if ~isfield(Options,'kmax') || isempty(Options.kmax)
   
   % Combine (1) and (2)
   minkmax = 20;
-  kmax = min(kmax,thresholdorder);
+  kmax = max(kmax,thresholdorder);
   kmax = max(kmax,minkmax); % at least 20
   logmsg(1,'  smaller of the two, but at least %d: %d',minkmax,kmax);
   


### PR DESCRIPTION
The bug fix for blochsteady uses the correct number of points as calculated from the maximum Fourier order if it is not specified in Options.nPoints to avoid "bandwidth" problems of the resulting time traces.
The Fourier order is now calculated such that the higher number of the two calculations of the Fourier order is used instead of the lower one.