### PR TITLE
nucdata bugfix

### DIFF
--- a/easyspin/isotopologues.m
+++ b/easyspin/isotopologues.m
@@ -112,7 +112,7 @@ if isempty(NucList)
   return
 end
 
-IsotopeList = nucdata('');
+IsotopeList = nucdata;
 
 customMixtures = any(NucList=='(');
 NucList = nucstring2list(NucList,'m');

--- a/easyspin/nucdata.m
+++ b/easyspin/nucdata.m
@@ -21,13 +21,7 @@
 
 function varargout = nucdata(Isotopes)
 
-if nargin==0, help(mfilename); return; end
-
-if iscell(Isotopes)
-  if numel(Isotopes)==1
-    Isotopes = Isotopes{1};
-  end
-end
+if nargout==0, help(mfilename); return; end
 
 %--------------------------------------------------------------
 persistent Elements IsotopeList
@@ -65,6 +59,12 @@ end
 if nargin==0
   varargout = {IsotopeList};
   return
+end
+
+if iscell(Isotopes)
+  if numel(Isotopes)==1
+    Isotopes = Isotopes{1};
+  end
 end
 
 if ~ischar(Isotopes) && ~iscell(Isotopes)

--- a/tests/nucdata_list.m
+++ b/tests/nucdata_list.m
@@ -1,0 +1,5 @@
+function ok = test()
+
+IsotopeList = nucdata;
+
+ok = isstruct(IsotopeList);


### PR DESCRIPTION
The recent changes in nucdata broke a lot of tests this was due to how isotopologues called nucdata. I changed the flow slightly which should resolve the problems. and added a new test.