### PR TITLE
Bug fixes for nucspinadd.m

### DIFF
--- a/easyspin/nucspinadd.m
+++ b/easyspin/nucspinadd.m
@@ -43,7 +43,7 @@ if isfield(Sys,'S')
   end
 end
 if isfield(Sys,'nn') && ~isempty(Sys.nn) && any(Sys.nn(:)~=0)
-  errpor('nucspinadd does not work if Sys.nn is present.');
+  error('nucspinadd does not work if Sys.nn is present.');
 end
 
 % Check Nuc
@@ -195,6 +195,10 @@ function Tnew = appendtensor(T0,T0Frame,T,TFrame,nNuclei,AQ,I)
 
 Atensor = AQ=='A';
 
+if ~Atensor && isempty(T)
+  T = zeros(1, 3);
+end
+
 if size(T0,1)==3*nNuclei
   nT0 = 9;
 elseif numel(T0)==nNuclei
@@ -225,10 +229,23 @@ newNuc = nNuclei+1;
 % Append T
 if fullT0 || fullT
   if ~fullT0
-    if Atensor
-      Tnew = [fullifyA(T0,T0Frame); T];
+    T0temp = zeros(3*nNuclei,3);
+    iList = 1:3:3*(nNuclei-1)+1;
+    if isempty(T0Frame)
+      T0FrameTemp = zeros(nNuclei, 3);
     else
-      Tnew = [fullifyQ(T0,T0Frame,I); T];
+      T0FrameTemp = T0Frame;
+    end
+    if Atensor
+      for iNuc0 = 1:nNuclei
+        T0temp(iList(iNuc0):iList(iNuc0)+2,:) = fullifyA(T0(iNuc0,:),T0FrameTemp(iNuc0,:));
+      end
+      Tnew = [T0temp; T];
+    else
+      for iNuc0 = 1:nNuclei
+        T0temp(iList(iNuc0):iList(iNuc0)+2,:) = fullifyQ(T0(iNuc0,:),T0FrameTemp(iNuc0,:),I(iNuc0));
+      end
+      Tnew = [T0temp; T];
     end
   elseif ~fullT
     if Atensor

--- a/tests/nucspinadd_mixed_hfi_nqi_dimensions.m
+++ b/tests/nucspinadd_mixed_hfi_nqi_dimensions.m
@@ -1,0 +1,13 @@
+function ok = test()
+
+
+Sys = struct('S',1/2,'g',[2 2 2.2]);
+Sys = nucspinadd(Sys,'14N',[3 3 9],[],[-1 -1 2]);
+Sys = nucspinadd(Sys,'63Cu',[50 50 520]);
+Sys = nucspinadd(Sys,'14N',[3 3 9],[],[-1 -1 2]);
+A = [10 0 0; 0 15 0; 0 0 30];
+Sys = nucspinadd(Sys,'14N',A);
+Q = [1 0 0; 0 2 0; 0 0 3];
+Sys = nucspinadd(Sys,'14N',[1],[],Q);
+
+ok = numel(Sys.A)==45 & numel(Sys.Q)==45;


### PR DESCRIPTION
This commit fixes three bugs in nucspinadd.m

1. Spelling mistake with `error`
2. If more than one nucleus has already been declared to `Sys` with isotropic/principle value notation, attempting to add a third with a full tensor fails as the function treats `T0` in `appendtensor` as a single nucleus when applying `fullifyA` and `fullifyQ`
3. If nuclei already exist in `Sys` with nqi and an additional nucleus is added *without* a nqi, `Sys.Q` is not updated with zeros, as a result the number of rows in `Sys.Q` no longer corresponds to the number of nuclei.