### PR TITLE
Corrected example in help description

### DIFF
--- a/easyspin/fieldmod.m
+++ b/easyspin/fieldmod.m
@@ -22,7 +22,7 @@
 %
 %     B = linspace(300,400,1001);  % mT
 %     spc = lorentzian(B,342,4);
-%     fieldmod(x,y,20);
+%     fieldmod(B,spc,20);
 
 % References
 % --------------------------------------------------


### PR DESCRIPTION
There was a small typo in the matlab example in the description of the function, making it impossible to just run the example code.