### PR TITLE
Physical constants 2022 CODATA

### DIFF
--- a/docsrc/amu.html
+++ b/docsrc/amu.html
@@ -29,7 +29,7 @@
 <div class="functitle">amu</div>
 
 <p>
-Atomic unit of mass in SI units.
+Atomic mass constant in SI units.
 </p>
 
 <!-- =================================================================== -->
@@ -44,7 +44,7 @@ value = amu
 <div class="subtitle">Description</div>
 
 <p>
-<code>amu</code> returns the SI value in kg of 1 amu, the atomic unit of mass,
+<code>amu</code> returns the SI value in kg of 1 amu, the atomic mass constant,
 in <code>value</code> and the standard deviation in <code>sigma</code> (if two output arguments are specified).
 </p>
 

--- a/docsrc/funcsalphabet.html
+++ b/docsrc/funcsalphabet.html
@@ -32,7 +32,7 @@ EasySpin functions - Alphabetical List
 
 <table>
 <tr><td style="width:110px"><a href="addnoise.html">addnoise</a></td><td>Add noise to a signal</td></tr>
-<tr><td><a href="amu.html">amu</a></td><td>Atomic unit of mass</td></tr>
+<tr><td><a href="amu.html">amu</a></td><td>Atomic mass constant</td></tr>
 <tr><td><a href="ang2vec.html">ang2vec</a></td><td>Converts polar angles to cartesian unit vector</td></tr>
 <tr><td><a href="angstrom.html">angstrom</a></td><td>Molecular-scale length unit</td></tr>
 <tr><td><a href="apowin.html">apowin</a></td><td>Apodization windows.</td></tr>

--- a/docsrc/funcscategory.html
+++ b/docsrc/funcscategory.html
@@ -160,7 +160,7 @@
 <tr><td><a href="nucqmom.html">nucqmom</a></td><td>Nuclear electric quadrupole moments</td></tr>
 <tr><td><a href="nucspin.html">nucspin</a></td><td>Nuclear spin quantum numbers</td></tr>
 <tr><td>&nbsp;</td><td></td></tr>
-<tr><td><a href="amu.html">amu</a></td><td>Atomic unit of mass</td></tr>
+<tr><td><a href="amu.html">amu</a></td><td>Atomic mass constant</td></tr>
 <tr><td><a href="angstrom.html">angstrom</a></td><td>Molecular-scale length unit</td></tr>
 <tr><td><a href="avogadro.html">avogadro</a></td><td>Avogadro constant</td></tr>
 <tr><td><a href="barn.html">barn</a></td><td>Conventional unit of nuclear quadrupole moments</td></tr>

--- a/easyspin/amu.m
+++ b/easyspin/amu.m
@@ -3,15 +3,14 @@
 %   u = amu
 %   [u,sigma] = amu
 %
-%   Returns the atomic mass unit
-%   in kg. sigma is the standard
-%   uncertainty.
+%   Returns the atomic mass unit in SI units, kg. 
+%   sigma is the standard uncertainty.
 
 function [u,sigma] = amu
 
-% 2018 CODATA value
+% 2022 CODATA value
 
-u =     1.66053906660e-27;
-sigma = 0.00000000050e-27;
+u =     1.66053906892e-27;
+sigma = 0.00000000052e-27;
 
 end

--- a/easyspin/angstrom.m
+++ b/easyspin/angstrom.m
@@ -9,8 +9,6 @@
 
 function A = angstrom
 
-% 1 Angstrom = 10^-10 m (exact)
-
-A = 1e-10;
+A = 1e-10; % exact
 
 end

--- a/easyspin/avogadro.m
+++ b/easyspin/avogadro.m
@@ -6,7 +6,7 @@
 
 function NA = avogadro
 
-% 2018 CODATA value
+% 2022 CODATA value
 
 NA =   6.02214076e23; % exact (as of SI redefinition 2019)
 

--- a/easyspin/barn.m
+++ b/easyspin/barn.m
@@ -9,7 +9,6 @@
 
 function b = barn
 
-% 1 barn = 10^-28 m^2 (exact)
 b = 1e-28;
 
 end

--- a/easyspin/bmagn.m
+++ b/easyspin/bmagn.m
@@ -3,14 +3,14 @@
 %   muB = bmagn
 %   [muB,sigma] = bmagn
 %
-%   Returns the Bohr magneton in joule per tesla.
+%   Returns the Bohr magneton in SI units, J T^-1.
 %   sigma is the standard uncertainty.
 
 function [mu,sigma] = bmagn
 
-% CODATA 2018 value
+% 2022 CODATA value
 
-mu =    9.2740100783e-24;
-sigma = 0.0000000028e-24;
+mu =    9.2740100657e-24;
+sigma = 0.0000000029e-24;
 
 end

--- a/easyspin/bohrrad.m
+++ b/easyspin/bohrrad.m
@@ -3,14 +3,14 @@
 %   a0 = bohrrad
 %   [a0,sigma] = bohrrad
 %
-%   Returns the Bohr radius in units of meters.
+%   Returns the Bohr radius in SI units, m.
 %   sigma is the standard uncertainty.
 
 function [a0,sigma] = bohrrad
 
-% 2018 CODATA value
+% 2022 CODATA value
 
-a0 =    0.529177210903e-10;
-sigma = 0.000000000080e-10;
+a0 =    5.29177210544e-11;
+sigma = 0.00000000082e-11;
 
 end

--- a/easyspin/boltzm.m
+++ b/easyspin/boltzm.m
@@ -2,11 +2,11 @@
 %
 %   kB = boltzm
 %
-%   Returns the Boltzmann constant in SI units, joule per kelvin.
+%   Returns the Boltzmann constant in SI units, J K^-1.
 
 function kB = boltzm
 
-% 2018 CODATA value
+% 2022 CODATA value
 
 kB = 1.380649e-23; % exact (as of SI redefinition 2019)
 

--- a/easyspin/clight.m
+++ b/easyspin/clight.m
@@ -2,14 +2,10 @@
 % 
 %   c = clight
 %
-%   Returns the vacuum speed of light in
-%   SI units, meters per second.
+%   Returns the vacuum speed of light in SI units, m S^-1.
 
-function [c,sigma] = clight
+function c = clight
 
-%   c = 299 792 458 m/s (exact)
-
-c = 299792458;
-sigma = 0;
+c = 299792458; % exact
 
 end

--- a/easyspin/echarge.m
+++ b/easyspin/echarge.m
@@ -2,11 +2,11 @@
 %
 %   e = echarge
 %
-%   Returns the (positive) elementary charge in SI units, in coulomb.
+%   Returns the (positive) elementary charge in SI units, C.
 
 function e = echarge
 
-% 2018 CODATA value
+% 2022 CODATA value
  
 e = 1.602176634e-19; % exact (as of 2019 SI redefinition)
 

--- a/easyspin/emass.m
+++ b/easyspin/emass.m
@@ -8,9 +8,9 @@
 
 function [me,sigma] = emass
 
-% 2018 CODATA value
+% 2022 CODATA value
 
-me =    9.1093837015e-31;
+me =    9.1093837139e-31;
 sigma = 0.0000000028e-31;
 
 end

--- a/easyspin/eps0.m
+++ b/easyspin/eps0.m
@@ -3,10 +3,13 @@
 %   e = eps0
 %
 %   Returns the electric constant (also known as vacuum
-%   permittivity) in SI units, F/m = C^2/N/m^2.
+%   permittivity) in SI units, F m^-1 = C^2 N^-1 m^-2.
 
-function e = eps0
+function [e, sigma] = eps0
 
-e = 1/mu0/clight^2;
+% 2022 CODATA value
+
+e =     8.8541878188e-12;
+sigma = 0.0000000014e-12;
 
 end

--- a/easyspin/evolt.m
+++ b/easyspin/evolt.m
@@ -3,11 +3,11 @@
 %   eV = evolt
 %
 %   Returns the electron volt, a conventional unit of energy,
-%   in SI units (joule).
+%   in SI units, J.
 
 function eV = evolt
 
-% 2018 CODATA value
+% 2022 CODATA value
  
 eV = echarge; % exact, as of SI redefinition 2019
 

--- a/easyspin/faraday.m
+++ b/easyspin/faraday.m
@@ -2,11 +2,11 @@
 %
 %   F = faraday
 %
-%   Returns the Faraday constant in SI units, coulomb per mole.
+%   Returns the Faraday constant in SI units, C mol^-1.
 
 function F = faraday
 
-% 2018 CODATA value
+% 2022 CODATA value
   
 F = evolt*avogadro; % exact, as of 2019 SI redefinition
 

--- a/easyspin/gammae.m
+++ b/easyspin/gammae.m
@@ -4,14 +4,14 @@
 %   [val,sig] = gammae
 %
 %   Returns the value of the gyromagnetic ratio of the electron, in SI
-%   units (radians per second per tesla, rad s^-1 T^-1).
+%   units, rad s^-1 T^-1.
 %   sigma is the standard deviation.
 
 function [value,sigma] = gammae
 
-% CODATA 2018 value, with added negative sign
+% 2022 CODATA value, with added negative sign
 
-value = -1.76085963023e11;
-sigma =  0.00000000053e11;
+value = -1.76085962784e11;
+sigma =  0.00000000055e11;
 
 end

--- a/easyspin/gfree.m
+++ b/easyspin/gfree.m
@@ -8,9 +8,9 @@
 
 function [g,sigma] = gfree
 
-% 2018 CODATA
+% 2022 CODATA value, with negated negative sign
 
-g =     2.00231930436256;
-sigma = 0.00000000000035;
+g =     2.00231930436092;
+sigma = 0.00000000000036;
 
 end

--- a/easyspin/hartree.m
+++ b/easyspin/hartree.m
@@ -4,13 +4,14 @@
 %   [E,sigma] = hartree
 %
 %   Returns the Hartree energy, the atomic unit of energy
-%   in joule. sigma is the standard uncertainty.
+%   in SI units, J. 
+%   sigma is the standard uncertainty.
 
 function [E,sigma] = hartree
 
-% 2018 CODATA value
-
-E =     4.3597447222071e-18;
-sigma = 0.0000000000085e-18;
+% 2022 CODATA value
+        
+E =     4.3597447222060e-18;
+sigma = 0.0000000000048e-18;
 
 end

--- a/easyspin/hbar.m
+++ b/easyspin/hbar.m
@@ -2,11 +2,12 @@
 %
 %   value = hbar
 %
-%   Returns the Planck constant over 2 pi, h/(2*pi), in J s rad^-1.
+%   Returns the Planck constant over 2 pi, h/(2*pi), 
+%   in SI units, J s rad^-1.
 
 function value = hbar
 
-% 2018 CODATA recommended value
+% 2022 CODATA value
  
 value = planck/2/pi; % exact, as of SI redefinition 2019
 

--- a/easyspin/molgas.m
+++ b/easyspin/molgas.m
@@ -2,11 +2,11 @@
 %
 %   R = molgas
 %
-%   Returns the molar gas constant in SI units, joule per mole per kelvin.
+%   Returns the molar gas constant in SI units, J mol^-1 K^-1
 
 function R = molgas
 
-% 2018 CODATA value
+% 2022 CODATA value
 
 R = avogadro*boltzm; % exact, as of SI redefinition 2019
 

--- a/easyspin/mu0.m
+++ b/easyspin/mu0.m
@@ -5,8 +5,11 @@
 %   Returns the magnetic constant (also known as vacuum
 %   permeability) in SI units (N A^-2 = T^2 m^3 J^-1).
 
-function m = mu0
+function [m,sigma] = mu0
 
-m = 1.25663706212e-6;
+% 2022 CODATA value
+
+m =     1.25663706127e-6;
+sigma = 0.00000000020e-6;
 
 end

--- a/easyspin/nmagn.m
+++ b/easyspin/nmagn.m
@@ -3,14 +3,14 @@
 %   mu = nmagn
 %   [mu,sigma] = nmagn
 %
-%   Returns the nuclear magneton in SI units, joule per tesla.
+%   Returns the nuclear magneton in SI units, J T^-1.
 %   sigma is the standard uncertainty.
 
 function [mu_n,sigma] = nmagn
 
-% 2018 CODATA recommended values
+% 2022 CODATA value
 
-mu_n =  5.0507837461e-27;
-sigma = 0.0000000015e-27;
+mu_n =  5.0507837393e-27;
+sigma = 0.0000000016e-27;
 
 end

--- a/easyspin/nmass.m
+++ b/easyspin/nmass.m
@@ -3,14 +3,14 @@
 %   mn = nmass
 %   [mn,sigma] = nmass
 %
-%   Returns the mass of the neutron, in kg.
+%   Returns the mass of the neutron in SI units, kg.
 %   sigma is the standard uncertainty.
 
 function [mn,sigma] = nmass
 
-% 2018 CODATA value
+% 2022 CODATA value
 
-mn =    1.67492749804e-27;
-sigma = 0.00000000095e-27;
+mn =    1.67492750056e-27;
+sigma = 0.00000000085e-27;
 
 end

--- a/easyspin/planck.m
+++ b/easyspin/planck.m
@@ -2,11 +2,11 @@
 %
 %   h = planck
 %
-%   Returns the Planck constant in SI units (J s = J/Hz).
+%   Returns the Planck constant in SI units (J s = J Hz^-1).
 
 function h = planck
 
-% 2018 CODATA recommended value
+% 2022 CODATA value
 
 h = 6.62607015e-34; % exact, as of 2019 SI redefinition
 

--- a/easyspin/pmass.m
+++ b/easyspin/pmass.m
@@ -3,14 +3,14 @@
 %   mp = pmass
 %   [mp,sigma] = pmass
 %
-%   Returns the mass of the proton, in kg.
+%   Returns the mass of the proton in SI units, kg.
 %   sigma is the standard uncertainty.
 
 function [mp,sigma] = pmass
 
-% 2018 CODATA value
+% 2022 CODATA value
 
-mp =    1.67262192369e-27;
-sigma = 0.00000000051e-27;
+mp =    1.67262192595e-27;
+sigma = 0.00000000052e-27;
 
 end

--- a/easyspin/rydberg.m
+++ b/easyspin/rydberg.m
@@ -3,14 +3,14 @@
 %   Rinf = rydberg
 %   [Rinf,sigma] = rydberg
 %
-%   Returns the Rydberg constant, in m^-1.
+%   Returns the Rydberg constant in SI units, m^-1.
 %   sigma is the standard uncertainty.
 
 function [Rinf,sigma] = rydberg
 
-% 2018 CODATA value
+% 2022 CODATA value
 
-Rinf = 10973731.568160;
-sigma =       0.000021;
+Rinf  = 10973731.568157;
+sigma =        0.000012;
 
 end

--- a/tests/amu_value.m
+++ b/tests/amu_value.m
@@ -1,6 +1,6 @@
 function ok = test()
 
 amu_val = amu;
-amu_ref = 1.66053906660e-27;
+amu_ref = 1.66053906892e-27;
 
 ok = areequal(amu_val,amu_ref,1e-12,'rel');

--- a/tests/bmagn_value.m
+++ b/tests/bmagn_value.m
@@ -1,5 +1,5 @@
 function ok = test()
 
 a = bmagn;
-b = 9.2740100783e-24;
-ok = areequal(a,b,1e-10,'rel');
+b = 9.2740100657e-24;
+ok = areequal(a,b,1e-11,'rel');

--- a/tests/bohrrad_value.m
+++ b/tests/bohrrad_value.m
@@ -1,6 +1,6 @@
 function ok = test()
 
 a = bohrrad;
-b = 0.529177210903e-10;
-ok = areequal(a,b,1e-10,'rel');
+b = 5.29177210544e-11;
+ok = areequal(a,b,1e-12,'rel');
 

--- a/tests/emass_value.m
+++ b/tests/emass_value.m
@@ -1,6 +1,6 @@
 function ok = test()
 
 a = emass;
-b = 9.1093837015e-31;
+b = 9.1093837139e-31;
 
-ok = areequal(a,b,1e-12,'rel');
+ok = areequal(a,b,1e-11,'rel');

--- a/tests/eps0_value.m
+++ b/tests/eps0_value.m
@@ -1,6 +1,6 @@
 function ok = test()
 
 eps0_val = eps0;
-eps0_ref = 8.8541878128e-12; % = 1/mu0/clight^2
+eps0_ref = 8.8541878188e-12; % = 1/mu0/clight^2
 
-ok = areequal(eps0_val,eps0_ref,1e-10,'rel');
+ok = areequal(eps0_val,eps0_ref,1e-11,'rel');

--- a/tests/gammae_value.m
+++ b/tests/gammae_value.m
@@ -2,8 +2,8 @@ function ok = test()
 
 
 val = gammae;
-ref = -1.76085963023e11;
+ref = -1.76085962784e11;
 
-ok = val==ref;
+ok = areequal(val,ref,1e-12,'abs');
 
 end

--- a/tests/gfree_value.m
+++ b/tests/gfree_value.m
@@ -3,5 +3,5 @@ function ok = test(opt)
 % Direct value check
 
 a = gfree;
-b = 2.00231930436256;
-ok = areequal(a,b,1e-14,'abs');
+b = 2.00231930436092;
+ok = areequal(a,b,1e-15,'abs');

--- a/tests/hartree_value.m
+++ b/tests/hartree_value.m
@@ -1,5 +1,5 @@
 function ok = test()
 
 a = hartree;
-b = 4.3597447222071e-18;
-ok = areequal(a,b,1e-13,'rel');
+b = 4.3597447222060e-18;
+ok = areequal(a,b,1e-14,'rel');

--- a/tests/mu0_value.m
+++ b/tests/mu0_value.m
@@ -1,5 +1,5 @@
 function ok = test()
 
 a = mu0;
-b = 1.25663706212e-6;
-ok= areequal(a,b,1e-10,'rel');
+b = 1.25663706127e-6;
+ok= areequal(a,b,1e-12,'rel');

--- a/tests/nmagn_value.m
+++ b/tests/nmagn_value.m
@@ -1,5 +1,5 @@
 function ok = test()
 
 a = nmagn;
-b = 5.0507837461e-27;
+b =  5.0507837393e-27;
 ok = areequal(a,b,1e-11,'rel');

--- a/tests/nmass_value.m
+++ b/tests/nmass_value.m
@@ -1,5 +1,5 @@
 function ok = test()
 
 a = nmass;
-b = 1.67492749804e-27;
+b = 1.67492750056e-27;
 ok = areequal(a,b,1e-12,'rel');

--- a/tests/pmass_value.m
+++ b/tests/pmass_value.m
@@ -1,5 +1,5 @@
 function ok = test()
 
 a = pmass;
-b = 1.67262192369e-27;
+b = 1.67262192595e-27;
 ok = areequal(a,b,1e-12,'rel');

--- a/tests/rydberg_value.m
+++ b/tests/rydberg_value.m
@@ -1,6 +1,7 @@
 function ok = test()
 
 a = rydberg;
-b = 10973731.568160;
+b = 10973731.568157;
+b = 10973731.568157;
 
-ok = areequal(a,b,1e-12,'rel');
+ok = areequal(a,b,1e-14,'rel');

--- a/tests/rydberg_value.m
+++ b/tests/rydberg_value.m
@@ -2,6 +2,5 @@ function ok = test()
 
 a = rydberg;
 b = 10973731.568157;
-b = 10973731.568157;
 
 ok = areequal(a,b,1e-14,'rel');


### PR DESCRIPTION
This addresses issue #340 
- The constant functions now include the updated recommended values and uncertainties. Apart from 
    updates to existing values/outputs several functions have had further changes:
    - `clight`: removed the uncertainty output argument which makes it consistent with the other *exact* constant functions
    - `eps0`: changed the value from `1/mu0/clight^2` to the 2022 CODATA recommended value and added an uncertainty value and output
    - `mu0`: added an uncertainty value and output
- Function docstrings are more consistent across constants
- Tests have been updated for the new values
- Previously in the EasySpin documentation amu is defined as the *atomic unit of mass* and assigned the value
    1.66053906892e-27. I think this is an error as the atomic unit of mass is not the same
    as the atomic mass unit (which is now known as the atomic mass constant).
    For example, in the NIST database
    - atomic unit of mass, symbol: \\(m_\mathrm{e}\\), quantity: 9.1093837139e10-31 kg
    - atomic mass constant, symbol: \\(m_\mathrm{u}\\), quantity: 1.66053906892e10-27 kg 
    In the documentation related to `amu` I have replaced the term *atomic unit of mass*
    with *atomic mass constant*.