### PR TITLE
Update orca2easyspin to read ORCA 6.0.0 files' g and A values

### DIFF
--- a/easyspin/orca2easyspin.m
+++ b/easyspin/orca2easyspin.m
@@ -76,8 +76,6 @@ else
   binaryPropFile = strcat(fullfile(output_path,output_name), output_ext,'.prop');
   textPropFile = strcat(fullfile(output_path,output_name),'_property.txt');
 end
-isStringScalar(mainOutputFile)
-disp(mainOutputFile)
 existMain = exist(mainOutputFile,'file');
 existPropBin = exist(binaryPropFile,'file');
 existPropTxt = exist(textPropFile,'file');

--- a/easyspin/orca2easyspin.m
+++ b/easyspin/orca2easyspin.m
@@ -72,10 +72,12 @@ elseif output_ext==".txt" && numel(output_name)>9 && output_name(end-8:end)=="_p
 else
   % main ORCA output file
   readmode = 'mainout';
-  mainOutputFile = fullfile(output_path,[output_name output_ext]);
-  binaryPropFile = fullfile(output_path,[output_name output_ext '.prop']);
-  textPropFile = fullfile(output_path,[output_name '_property.txt']);
+  mainOutputFile = strcat(fullfile(output_path,output_name), output_ext);
+  binaryPropFile = strcat(fullfile(output_path,output_name), output_ext,'.prop');
+  textPropFile = strcat(fullfile(output_path,output_name),'_property.txt');
 end
+isStringScalar(mainOutputFile)
+disp(mainOutputFile)
 existMain = exist(mainOutputFile,'file');
 existPropBin = exist(binaryPropFile,'file');
 existPropTxt = exist(textPropFile,'file');

--- a/easyspin/private/orca2easyspin_maintxt.m
+++ b/easyspin/private/orca2easyspin_maintxt.m
@@ -229,7 +229,7 @@ for iStructure = 1:nStructures
       if regexp(L{k},'^\s*Nucleus\s*')
         iAtom = sscanf(L{k}(9:end),'%d',1)+1;
         [~,qrefEl] = referenceisotope(Element{iAtom});
-      elseif regexp(L{k},'^\s*Raw HFC matrix')
+      elseif regexp(L{k},'^\s*(Raw HFC matrix|Total HFC matrix)')
         if strncmp(L{k+1}(2:4),'---',3)
           idx = k+2;
         else
@@ -366,7 +366,7 @@ end
 function k = findheader(header,L,krange)
 header_found = false;
 for k = krange
-  if strcmp(L{k},header)
+  if strncmp(L{k},header,length(header))
     header_found = true;
     break
   end

--- a/easyspin/private/orca2easyspin_maintxt.m
+++ b/easyspin/private/orca2easyspin_maintxt.m
@@ -157,7 +157,6 @@ for iStructure = 1:nStructures
   if ~isempty(k)
     if (~isempty(OrcaVersion)) && (OrcaVersion(1) == '6')
       k = k+10;
-      disp('kf')
     else
       k = k+3;
     end

--- a/easyspin/private/orca2easyspin_maintxt.m
+++ b/easyspin/private/orca2easyspin_maintxt.m
@@ -155,7 +155,12 @@ for iStructure = 1:nStructures
   %------------------------------------------------------------------------
   k = findheader('ELECTRONIC G-MATRIX',L,krange);
   if ~isempty(k)
-    k = k+3;
+    if (~isempty(OrcaVersion)) && (OrcaVersion(1) == '6')
+      k = k+10;
+      disp('kf')
+    else
+      k = k+3;
+    end
     % read raw asymmetric g matrix
     g_raw = readmatrix(L(k:k+2));
     g_sym = (g_raw.'*g_raw)^(1/2);

--- a/easyspin/private/orca2easyspin_maintxt.m
+++ b/easyspin/private/orca2easyspin_maintxt.m
@@ -355,7 +355,6 @@ end
 
 end
 
-
 function M = readmatrix(L,startidx)
 if nargin<2, startidx = 1; end
 M(1,:) = sscanf(L{1}(startidx:end),'%f %f %f').';


### PR DESCRIPTION
This updates orca2easyspin.m and orca2easyspin_maintext.m to work with new orca files. Changes are mostly to adjust line number offsets and change string parsing/regex so it works with both orca5.0 and orca6.0 files. No new crashes in `estest orca2easyspin` are introduced; four tests still crash due to dropping support for loading `_parameters.txt` files in ORCA 5+. 

Note: I am not familiar with ORCA Q or D calculations, so I wasn't able to test against that. If someone would like to provide an ORCA output file, I'd be happy to work on it.