### PR TITLE
Stops stev.m forming a full matrix even when sparse option given

### DIFF
--- a/easyspin/stev.m
+++ b/easyspin/stev.m
@@ -173,8 +173,9 @@ else
 end
 
 % Clean small numerical errors
-idx = abs(Op)<1e-14 & Op~=0;
-Op(idx) = 0;
+Op(Op(find(Op))<1e-14)=0;
+%Alternatively:
+%Op = spfun(@(x)round(x,14),Op); % but this will round all values
 
 if ~useSparseMatrices
   Op = full(Op);


### PR DESCRIPTION
The final step "Clean small numerical errors", forms a full logical matrix (even if the sparse option was given) when checking that every element is greater than 1e-14. 

This modification uses find() first so that only non zero entries of Op are compared.