### PR TITLE
Fix dbstack index issue for command window exec

### DIFF
--- a/easyspin/endorfrq.m
+++ b/easyspin/endorfrq.m
@@ -581,7 +581,7 @@ Info.Selectivity = Selectivity;
 
 % Reshape arrays in the case of crystals with site splitting
 d = dbstack;
-saltCall = numel(d)>2 && strcmp(d(2).name,'salt');
+saltCall = numel(d)>1 && strcmp(d(2).name,'salt');
 if nSites>1 && ~saltCall
   siz = [nTransitions*nSites, numel(Pdat)/nTransitions/nSites];
   Pdat = reshape(Pdat,siz);

--- a/easyspin/resfields.m
+++ b/easyspin/resfields.m
@@ -1548,7 +1548,7 @@ end
 
 % Reshape arrays in the case of crystals with multiple sites
 d = dbstack;
-pepperCall = strcmp(d(2).name,'pepper');
+pepperCall = numel(d)>1 && strcmp(d(2).name,'pepper');
 if ~pepperCall
   if nSites>1
     % Pdat, Idat, Wdat have size [nTransitions, nSites*nOrientations]

--- a/easyspin/resfields_perturb.m
+++ b/easyspin/resfields_perturb.m
@@ -599,7 +599,7 @@ end
 
 % Reshape arrays in the case of crystals with site splitting
 d = dbstack;
-pepperCall = numel(d)>2 && strcmp(d(2).name,'pepper');
+pepperCall = numel(d)>1 && strcmp(d(2).name,'pepper');
 if nSites>1 && ~pepperCall
   siz = [nTransitions*nSites, numel(B)/nTransitions/nSites];
   B = reshape(B,siz);

--- a/easyspin/resfreqs_matrix.m
+++ b/easyspin/resfreqs_matrix.m
@@ -1014,7 +1014,7 @@ end
 
 % Reshape arrays in the case of crystals with multiple sites
 d = dbstack;
-pepperCall = strcmp(d(2).name,'pepper');
+pepperCall = numel(d)>1 && strcmp(d(2).name,'pepper');
 if ~pepperCall
   if nSites>1
     % Pdat, Idat, Wdat have size [nTransitions, nSites*nOrientations]

--- a/easyspin/resfreqs_perturb.m
+++ b/easyspin/resfreqs_perturb.m
@@ -574,7 +574,7 @@ end
 
 % Reshape arrays in the case of crystals with site splitting
 db = dbstack;
-pepperCall = numel(db)>2 && strcmp(db(2).name,'pepper');
+pepperCall = numel(db)>1 && strcmp(db(2).name,'pepper');
 if nSites>1 && ~pepperCall
   siz = [nTransitions*nSites, numel(nu)/nTransitions/nSites];
   nu = reshape(nu,siz);


### PR DESCRIPTION
Check call stack depth before using strcmp on upper stack. This prevents errors when functions like resfields are run directly from the command window.