### PR TITLE
Extend basecorr to handle 2D mask region

### DIFF
--- a/easyspin/basecorr.m
+++ b/easyspin/basecorr.m
@@ -103,8 +103,9 @@ if ~isempty(region)
   if ~islogical(region)
     error('region (4th input) must be a logical array.');
   end
-  if twoDimFit
-    warning('basecorr: Baseline correction with mask is only available for 1D fits.')
+  if twoDimFit & size(region) ~= size(data)
+    warning(['basecorr: for 2D fit, region (4th input) must be ' ...
+        'logical with the same size as data.'])
   end
 end
 
@@ -128,7 +129,11 @@ if twoDimFit
   end
 
   % Fit polynomial and evaluate baseline
-  p = D\data(:);
+  if isempty(region)
+      p = D\data(:);
+  else
+      p = D(region(:), :)\data(region(:));
+  end
   baseline = D*p;
   baseline = reshape(baseline,r,c);
 

--- a/tests/basecorr_twodim.m
+++ b/tests/basecorr_twodim.m
@@ -2,12 +2,24 @@ function ok = test()
 
 % Test two-dimensional polynomial baseline correction
 
-x = linspace(0,1,7).';
-y = linspace(0,1,6);
-data = 1 + 0.12*x - 0.9*y + x.^2 + 0.445*y.^2 - 0.2*x.*y;
+x = linspace(0,1,201).';
+y = linspace(0,1,101);
+data0 = gaussian(x,0.4,0.1)*gaussian(y,0.6,0.1);
+baseline = 1 + 0.12*x - 0.9*y + x.^2 + 0.445*y.^2 - 0.2*x.*y;
+
+data = data0 + baseline;
 
 dim = [];
 n = [2 2];
-datacorr = basecorr(data,dim,n);
+baselineCheck = basecorr(baseline,dim,n);
 
-ok = max(abs(datacorr))<1e-10;
+regionx = x<0.1 | x>0.7;
+regiony = y<0.2 | y>0.9;
+region = regionx | regiony;
+
+[datac, baselinec] = basecorr(data, dim, n, region);
+
+ok(1) = max(abs(baselineCheck), [], 'all')<1e-10;
+threshold = 1e-10;
+ok(2) = areequal(datac,data0,threshold,'abs');
+ok(3) = areequal(baseline,baselinec,threshold,'abs');


### PR DESCRIPTION
I propose that basecorr should also accept a 2D logical mask of the same size of the data. test/basecorr_twodim was accordingly modified to check for correct behavior of basecorr.