### PR TITLE
Rework of resonatorprofile

### DIFF
--- a/docsrc/releases.html
+++ b/docsrc/releases.html
@@ -39,6 +39,7 @@ $ReleaseID$
 <li>The new function <a class="esf" href="gamman">gamman</a> provides nuclear gyromagnetic ratio.</li>
 <li>The new function <a class="esf" href="isto2stev">isto2stev</a> provides the transformation matrix between irreducible spherical tensor operators and Stevens operators.</li>
 <li>The new function <a class="esf" href="phasecorr">phasecorr</a> phase-corrects signals by minimizing the second moment of the imaginary part.</li>
+<li>The function <a class="esf" href="resonatorprofile">resonatorprofile</a> now can also calculate transmitted power, S11, VSWR, and return loss of a resonator.</li>
 </ul>
 
 <p>Major bug fixes</p>

--- a/docsrc/resonatorprofile.html
+++ b/docsrc/resonatorprofile.html
@@ -44,17 +44,21 @@ out = resonatorprofile(nu,nu0,Qu,beta,type)
 H = resonatorprofile(nu,nu0,Qu,beta,'transferfunction')
 Gamma = resonatorprofile(nu,nu0,Qu,beta,'voltagereflection')
 Prefl = resonatorprofile(nu,nu0,Qu,beta,'powerreflection')
+Ptrans = resonatorprofile(nu,nu0,Qu,beta,'powertrasmission')
+S11 = resonatorprofile(nu,nu0,Qu,beta,'S11')
+RL = resonatorprofile(nu,nu0,Qu,beta,'returnloss')
+VSWR = resonatorprofile(nu,nu0,Qu,beta,'VSWR')
 </pre>
 
 <!-- ====================================================== -->
 <div class="subtitle">Description</div>
 
 <p>
-This function computes the resonator profile and can return the transfer function, the voltage reflection coefficient or the power reflection coefficient. <code>nu</code> is the frequency range vector, in GHz, over which it is computed. If it is empty, an appropriate range is chose automatically. <code>nu0</code> is the resonator resonance frequency in GHz. <code>Qu</code> is the unloaded Q-factor of the resonator. <code>beta</code> is the coupling coefficient: 1 for critical coupling (matched), less than 1 for undercoupling, and greater than 1 for overcoupling.
+This function computes the resonator profile and can return the transfer function, the voltage reflection coefficient, the power reflection coefficient, the power transmission coefficient, the S11 parameter, the return loss, or the voltage standing wave ration (VSWR). <code>nu</code> is the frequency range vector, in GHz, over which it is computed. If it is empty, an appropriate range is chose automatically. <code>nu0</code> is the resonator resonance frequency, in GHz. <code>Qu</code> is the unloaded Q-factor of the resonator (i.e. the theoretical Q factor of the resonator by itself, without connection to a transmission line). <code>beta</code> is the coupling coefficient: 1 for critical coupling (matched), less than 1 for undercoupling, and greater than 1 for overcoupling.
 </p>
 
 <p>
-The loaded Q-factor is related to the unloaded Q-factor <code>Qu</code> and the coupling coefficient <code>beta</code> through:
+The loaded Q-factor (which takes the coupling to the transmission line into account) is related to the unloaded Q-factor <code>Qu</code> and the coupling coefficient <code>beta</code> through:
   <div class="eqn">
 	<img src="eqn/resonatorprofile1.png" alt="[eqn]"><!--MATH
 	\begin{equation*}
@@ -65,34 +69,21 @@ The loaded Q-factor is related to the unloaded Q-factor <code>Qu</code> and the 
 </p>
 
 <p>
-The option <code>type</code> can be used to request either of the following:
+The option <code>type</code> can be used to request one of the following quantities
 <ul>
-  <li><code>transferfunction</code> - the resonator transfer function 
-  <div class="eqn">
-	<img src="eqn/resonatorprofile2.png" alt="[eqn]"><!--MATH
-	\begin{equation*}
-	H(\nu) = \frac{1}{1+ i Q_U \left(\frac{\nu}{\nu_0} - \frac{\nu_0}{\nu}\right)}
-	\end{equation*}
-	-->
-	</div>  
+  <li><code>transferfunction</code> - the resonator transfer function (using the loaded Q factor)
   </li>
   <li><code>voltagereflection</code> - the voltage reflection coefficient, i.e. the ratio of the E-fields of the reflected wave and the incoming wave
-  <div class="eqn">
-	<img src="eqn/resonatorprofile3.png" alt="[eqn]"><!--MATH
-	\begin{equation*}
-	\Gamma = \frac{1 - \beta + i Q_U \left(\frac{\nu}{\nu_0} - \frac{\nu_0}{\nu}\right)}{1 + \beta + i Q_U \left(\frac{\nu}{\nu_0} - \frac{\nu_0}{\nu}\right)} = \frac{1-\beta H(\nu)}{1 +\beta H(\nu)}
-	\end{equation*}
-	-->
-	</div>  
   </li>
-  <li><code>powerreflection</code> - the power reflection coefficient
-  <div class="eqn">
-	<img src="eqn/resonatorprofile4.png" alt="[eqn]"><!--MATH
-	\begin{equation*}
-	P_\text{reflected} = |\Gamma|^2
-	\end{equation*}
-	-->
-	</div>  
+  <li><code>powerreflection</code> - the power reflection coefficient, i.e. the fraction of power reflected off the resonator
+  </li>
+  <li><code>powertransmission</code> - the power transmission coefficient, i.e. the fraction of power transmitted into the resonator
+  </li>
+  <li><code>S11</code> - the S11 scattering parameter, equal to the voltage reflection coefficient
+  </li>
+  <li><code>returnloss</code> - the return loss, equal to the power reflection coefficient, expressed in dB
+  </li>
+  <li><code>VSWR</code> - the voltage standing wave ratio
   </li>
 </ul> 
 </p>
@@ -105,26 +96,28 @@ If no output is requested, <code>resonatorprofile</code> plots the results.
 <div class="subtitle">Examples</div>
 
 <p>
-Here is a simple example
+Here is a simple example for a power reflection curve, as used in EPR for tuning and matching:
 </p>
 
 <pre class="matlab">
 nu = linspace(9.2,9.8,1001);   % GHz
 nu0 = 9.5;                     % GHz
-Qu = 1000;
+Qu = 3000;
 beta = 1;
-resonatorprofile(nu,nu0,Qu,beta,'voltagereflection');
+resonatorprofile(nu,nu0,Qu,beta,'powerreflection');
 </pre>
 
 <p>
-To plot the power reflection coefficient on a logarithmic dB scale, use
+For determining the microwave B1 acting on the spins in the EPR sample inside the resonator, the magnitude of the transfer function is relevant:
 </p>
 
 <pre class="matlab">
-P_refl = resonatorprofile(nu,nu0,Qu,beta,'powerreflection');
-plot(nu,10*log10(P_refl));
-xlabel('frequency (GHz)');
-ylabel('reflected power (dB)');
+Qu = 200;
+P_trans = resonatorprofile(nu,nu0,Qu,beta,'powertransmission');
+H = resonatorprofile(nu,nu0,Qu,beta,'transferfunction');
+plot(nu,P_trans,nu,abs(H));
+legend('transmitted power','|transfer function|')
+legend boxoff
 </pre>
 
 <!-- ====================================================== -->

--- a/docsrc/resonatorprofile.html
+++ b/docsrc/resonatorprofile.html
@@ -37,8 +37,8 @@ Resonator profile
 
 <pre class="matlab">
 resonatorprofile(nu,nu0,Qu,beta,type)
-out = resonatorprofile(nu,nu0,Qu,beta,type)
-[nu,out] = resonatorprofile([],nu0,Qu,beta,type)
+result = resonatorprofile(nu,nu0,Qu,beta,type)
+[nu,result] = resonatorprofile([],nu0,Qu,beta,type)
 
 % Different output options
 H = resonatorprofile(nu,nu0,Qu,beta,'transferfunction')

--- a/easyspin/functionSignatures.json
+++ b/easyspin/functionSignatures.json
@@ -4383,7 +4383,7 @@
     ]
   },
   "resonatorprofile": {
-    "description": "Resonator profile (transfer function, voltage reflection coefficient or power reflection coefficient)",
+    "description": "Resonator characteristics (transfer function, voltage reflection coefficient, power reflection coefficient, etc)",
     "inputs": [
       {
         "name": "nu",
@@ -4399,7 +4399,8 @@
         "kind": "required",
         "type": [
           "numeric",
-          "scalar"
+          "scalar",
+          "positive"
         ],
         "purpose": "resonator resonance frequency, GHz"
       },
@@ -4418,7 +4419,8 @@
         "kind": "required",
         "type": [
           "numeric",
-          "scalar"
+          "scalar",
+          "positive"
         ],
         "purpose": "coupling coefficient"
       },
@@ -4426,7 +4428,8 @@
         "name": "type",
         "kind": "required",
         "type": [
-          "char"
+          "char",
+          "choices={'powerreflection','powertransmission','transferfunction','voltagereflection','S11','VSWR','returnloss'}"
         ],
         "purpose": "type of output to return"
       }
@@ -4963,7 +4966,7 @@
           "numeric",
           "scalar",
           "cell",
-		  "choices={'maxabs','int','dint','none'}"
+          "choices={'maxabs','int','dint','none'}"
         ],
         "purpose": "rescale mode for slices, default 'maxabs'"
       },

--- a/easyspin/pulse.m
+++ b/easyspin/pulse.m
@@ -783,7 +783,7 @@ else
       % Calculate ideal resonator transfer function
       f0 = Par.ResonatorFrequency*1e3; % center frequency
       QL = Par.ResonatorQL; % loaded Q-value
-      profile = abs(resonatorprofile(newaxis,f0,QL,'transferfunction'));
+      profile = abs(resonatorprofile(newaxis,f0,2*QL,1,'transferfunction'));
     end
     
     if strcmp(FrequencyModulation,'uniformq') || strcmp(Par.Type,'sech/tanh')

--- a/easyspin/resonator.m
+++ b/easyspin/resonator.m
@@ -254,7 +254,7 @@ function [f,H] = transferfunction(type,varargin)
 %    https://doi.org/10.1016/j.jmr.2015.12.014
 
 % Ideal transfer function (RLC series circuit)
-Hideal = @(f,f0,Q,nu_max) nu_max*resonatorprofile(f,f0,Q,'transferfunction');
+Hideal = @(f,f0,QL,nu_max) nu_max*resonatorprofile(f,f0,2*QL,1,'transferfunction');
 
 switch type
   case 'ideal'

--- a/easyspin/resonatorprofile.m
+++ b/easyspin/resonatorprofile.m
@@ -39,7 +39,7 @@ function varargout = resonatorprofile(nu,nu0,Qu,beta,type)
 %    type=='transferfunction':  transfer function H (= admittance)
 %    type=='voltagereflection': the voltage reflection coefficient Gamma 
 %                (ratio of E-field amplitudes of reflected and incoming wave)
-%    type=='powerreflecton': the power reflection coefficient abs(Gamma)^2
+%    type=='powerreflection': the power reflection coefficient abs(Gamma)^2
 %    type=='S11': the S11 scattering parameter
 %    type=='VSWR': the voltage standing wave ratio
 %    type=='returnloss': the return loss, in dB

--- a/easyspin/resonatorprofile.m
+++ b/easyspin/resonatorprofile.m
@@ -70,7 +70,7 @@ if nargin~=5
 end
 
 if ~isempty(nu)
-  if ~isnumeric(nu) || ~isreal(nu) || any(nu<=0)
+  if ~isnumeric(nu) || ~isreal(nu) || any(nu<0)
     error('The frequency axis (1st input) must be a 1D array of positive numbers.');
   end
 end

--- a/easyspin/resonatorprofile.m
+++ b/easyspin/resonatorprofile.m
@@ -2,8 +2,8 @@ function varargout = resonatorprofile(nu,nu0,Qu,beta,type)
 % resonatorprofile  Various quantities characterizing a microwave resonator
 %
 %  resonatorprofile(nu,nu0,Qu,beta,type)
-%  out = resonatorprofile(nu,nu0,Qu,beta,type)
-%  [nu,out] = resonatorprofile([],nu0,Qu,beta,type)
+%  result = resonatorprofile(nu,nu0,Qu,beta,type)
+%  [nu,result] = resonatorprofile([],nu0,Qu,beta,type)
 %
 %  H = resonatorprofile(nu,nu0,Qu,beta,'transferfunction')
 %  Gamma = resonatorprofile(nu,nu0,Qu,beta,'voltagereflection')
@@ -70,7 +70,7 @@ if nargin~=5
 end
 
 if ~isempty(nu)
-  if ~isnumeric(nu) || ~isreal(nu) || any(nu<0)
+  if ~isnumeric(nu) || ~isreal(nu) || any(nu<=0)
     error('The frequency axis (1st input) must be a 1D array of positive numbers.');
   end
 end
@@ -87,6 +87,9 @@ if ~isnumeric(beta) || ~isscalar(beta) || ~isreal(beta) || beta<=0
   error(sprintf(['The coupling coefficient beta (4th input) must be a positive number.\n'...
     '(1 for critical coupling, 0<beta<1 for undercoupling, >1 for overcoupling.']));
 end
+
+validStrings = {'powerreflection','voltagereflection','transferfunction','powertransmission','S11','returnloss','VSWR'};
+type = validatestring(type,validStrings,mfilename,'type (5th input)');
 
 % Calculations
 %-------------------------------------------------------------------------------
@@ -195,7 +198,7 @@ switch nargout
     end
     xlabel('frequency (GHz)');
     xline(nu0,'--','');
-    title(sprintf('{\\nu}_0 = %g GHz, {\\it{Q}}_u = %d, \\beta = %g, {\\it{Q}}_L = %g',nu0,Qu,beta,Qu/(1+beta)));
+    title(sprintf('{\\nu}_0 = %g GHz, {\\it{Q}}_u = %g, \\beta = %g, {\\it{Q}}_L = %g',nu0,Qu,beta,Qu/(1+beta)));
 
   case 1
     varargout = {result};

--- a/easyspin/resonatorprofile.m
+++ b/easyspin/resonatorprofile.m
@@ -1,5 +1,5 @@
 function varargout = resonatorprofile(nu,nu0,Qu,beta,type)
-% resonatorprofile  Resonator profile
+% resonatorprofile  Various quantities characterizing a microwave resonator
 %
 %  resonatorprofile(nu,nu0,Qu,beta,type)
 %  out = resonatorprofile(nu,nu0,Qu,beta,type)
@@ -7,102 +7,201 @@ function varargout = resonatorprofile(nu,nu0,Qu,beta,type)
 %
 %  H = resonatorprofile(nu,nu0,Qu,beta,'transferfunction')
 %  Gamma = resonatorprofile(nu,nu0,Qu,beta,'voltagereflection')
-%  P = resonatorprofile(nu,nu0,Qu,beta,'powerreflection')
+%  Gamma2 = resonatorprofile(nu,nu0,Qu,beta,'powerreflection')
+%  Gamma2 = resonatorprofile(nu,nu0,Qu,beta,'powertransmission')
+%  S11 = resonatorprofile(nu,nu0,Qu,beta,'S11')
+%  RL = resonatorprofile(nu,nu0,Qu,beta,'returnloss')
+%  VSWR = resonatorprofile(nu,nu0,Qu,beta,'VSWR')
 %
-%  Calculates the reflection coefficient for a reflection resonator, i.e. the
-%  fraction of voltage from an incoming wave that is reflected by the resonator.
+%  Calculates characteristics of a microwave reflection resonator such as the
+%  reflected voltage or power and the transmitted power.
 %
 %  Inputs:
 %    nu      frequency range array, GHz
 %    nu0     resonator frequency, GHz
 %    Qu      unloaded Q-factor of the resonator
-%    beta    coupling coefficient
-%              beta<1: undercoupled
+%    beta    coupling coefficient between resonator and transmission line
+%              0<beta<1: undercoupled
 %              beta=1: critically coupled (matched)
 %              beta>1: overcoupled
-%    type    type of output to return, 'transferfunction',
-%            'voltagereflection' or 'powerreflection'
+%    type    type of output to return, possible values:
+%              'transferfunction'
+%              'voltagereflection'
+%              'powerreflection',
+%              'powertransmission',
+%              'S11',
+%              'returnloss'
+%              'VSWR'
 %
 %    If nu is [], then an appropriate frequency range is chosen automatically.
 %
 %  Outputs:
-%    if type = 'transferfunction', the transfer function H is returned
-%    if type = 'voltagereflecton', the voltage reflection coefficient Gamma 
-%                (ratio of E-field amplitudes of reflected and incoming wave) is returned
-%    if type = 'powerreflecton', the power reflection coefficient abs(Gamma)^2 is returned
+%    type=='transferfunction':  transfer function H (= admittance)
+%    type=='voltagereflection': the voltage reflection coefficient Gamma 
+%                (ratio of E-field amplitudes of reflected and incoming wave)
+%    type=='powerreflecton': the power reflection coefficient abs(Gamma)^2
+%    type=='S11': the S11 scattering parameter
+%    type=='VSWR': the voltage standing wave ratio
+%    type=='returnloss': the return loss, in dB
 %
 %    If no output is requested, the results are plotted.
 %
 %  Example:
-%    nu = linspace(9.2,9.8,1001);
-%    nu0 = 9.5;
+%    nu = linspace(9.2,9.8,1001);  % GHz
+%    nu0 = 9.5;  % GHz
 %    Qu = 1000;
 %    beta = 1;
-%    resonatorprofile(nu,nu0,Qu,beta,'voltagereflection');
+%    resonatorprofile(nu,nu0,Qu,beta,'powerreflection');
+
+% References:
+% - Doll et al, J.Magn.Reson. 2013, https://doi.org/10.1016/j.jmr.2013.01.002
+% - Krymov et al, J.Magn.Reson. 2003, https://doi.org/10.1016/S1090-7807(03)00109-5
+% - Pozar, Microwave Engineering, 4th ed. (2012), Ch.6
 
 if nargin==0
   help(mfilename);
   return
 end
 
-if nargin==4
-  if ischar(beta)
-    type = beta;
-    beta = [];
-  else
-    error('Please specify the type of requested output type, ''transferfunction'', ''voltagereflection'', or ''powerreflection''.')
+% Input parameter checks
+%-------------------------------------------------------------------------------
+if nargin~=5
+  error('Five inputs (nu, nu0, Qu, beta, type) are required.');
+end
+
+if ~isempty(nu)
+  if ~isnumeric(nu) || ~isreal(nu) || any(nu<0)
+    error('The frequency axis (1st input) must be a 1D array of positive numbers.');
   end
 end
 
-if isempty(beta) && contains(type,'reflection')
-  error('The coupling coefficient beta is required as a fourth input argument to resonatorprofile().')
+if ~isnumeric(nu0) || ~isscalar(nu0) || ~isreal(nu0) || nu0<=0
+  error('The resonator frequency (2nd input) must be a positive number.');
 end
 
+if ~isnumeric(Qu) || ~isscalar(Qu) || ~isreal(Qu) || Qu<=0
+  error('The unloaded Q factor (3th input) must be a positive number.');
+end
+
+if ~isnumeric(beta) || ~isscalar(beta) || ~isreal(beta) || beta<=0
+  error(sprintf(['The coupling coefficient beta (4th input) must be a positive number.\n'...
+    '(1 for critical coupling, 0<beta<1 for undercoupling, >1 for overcoupling.']));
+end
+
+% Calculations
+%-------------------------------------------------------------------------------
+% Calculate loaded Q factor
+QL = Qu/(1+beta);  % loaded Q
+
+% Set up frequency axis if not provided
 if isempty(nu)
-  dnu = nu0/Qu*10;
+  bw = nu0/QL;  % bandwidth
+  dnu = bw*10;
   nu = linspace(max(nu0-dnu,0),nu0+dnu,1001);
 end
 
-% Transfer function for an ideal RLC series circuit
-H = @(nu,nu0,Q) 1./(1+1i*Q*(nu/nu0-nu0./nu));
+% Voltage reflection coefficient (=S11) for loaded resonator
+xi = nu/nu0 - nu0./nu;  % == approx 2*(nu-nu0)/nu0
+Gamma = (1-beta+1i*Qu*xi)./(1+beta+1i*Qu*xi);  % Krymov Eqs.(6) and (7)
 
+% Calculate desired quantity
 switch type
   case 'transferfunction'
-    if ~isempty(beta)
-      Q = Qu/(1+beta);
-    else
-      Q = Qu;
-    end
-    out = H(nu,nu0,Q);
+    H = 1./(1+1i*QL*xi);  % Doll 2013 Eq.(5)
+    result = H;
+
   case 'voltagereflection'
-    out = (1 - beta*H(nu,nu0,Qu))./(1 + beta*H(nu,nu0,Qu)); % voltage reflection coefficient
+    result = Gamma;
+
   case 'powerreflection'
-    out = abs((1 - beta*H(nu,nu0,Qu))./(1 + beta*H(nu,nu0,Qu))).^2; % power reflection coefficient
+    Gamma2 = 1 - 4*beta./(Qu^2*xi.^2+(1+beta).^2);
+    %Gamma2 = abs(Gamma).^2;  % equivalent
+    result = Gamma2;
+
+  case 'powertransmission'
+    Ptrans = 4*beta./(Qu^2*xi.^2+(1+beta).^2);  % Lorentzian
+    %Ptrans = 1 - abs(Gamma).^2;  % equivalent
+    result = Ptrans;
+
+  case 'S11'
+    S11 = Gamma;
+    result = S11;
+
+  case 'returnloss'
+    RL = -20*log10(abs(Gamma));  % Pozar, p. 58, eq. (2.38)
+    result = RL;
+
+  case 'VSWR'
+    VSWR = (1+abs(Gamma))./(1-abs(Gamma));  % Pozar, p. 58, eq. (2.41)
+    result = VSWR;
+
+  otherwise
+    error(sprintf(['Type (5th input) must be one of the following:\n  ''transferfunction'', ''voltagereflection'','...
+      '''powerreflection'', ''powertransmission'', ''S11'', ''VSWR'', ''returnloss''.']));
 end
 
+% Plotting, output
+%-------------------------------------------------------------------------------
+ylims = [];
 switch nargout
   case 0
     switch type
       case 'transferfunction'
-        plot(nu,real(out))       % transfer function
-        ylabel('H, real part of the transfer function');
+        plot(nu,real(result),nu,imag(result))
+        ylabel('Re({\itH}), Im({\itH}), transfer function');
+        legend('Re({\itH})', 'Im({\itH})','AutoUpdate','off');
+        legend boxoff
+        ylims = [-1 1];
+
       case 'voltagereflection'
-        plot(nu,abs(out));       % reflected voltage
-        ylabel('|\Gamma|, norm of voltage reflection coefficient');
+        plot(nu,real(result),nu,imag(result),nu,abs(result));
+        ylabel('Re({\it\Gamma}), Im({\it\Gamma}), |{\it\Gamma}|, voltage reflection coefficient');
+        ylims = [-1 1];
+        legend('Re({\it\Gamma})','Im({\it\Gamma})','|{\it\Gamma}|','AutoUpdate','off');
+        legend boxoff
+        yline(0)
+
       case 'powerreflection'
-        plot(nu,out);            % reflected power
-        ylabel('P_{reflected}, power reflection coefficient');
+        plot(nu,result);
+        ylabel('|{\it\Gamma}|^2, power reflection coefficient');
+        ylims = [0 1];
+
+      case 'powertransmission'
+        plot(nu,result);
+        ylabel('{\itP}_{trans}, power transmission coefficient');
+        ylims = [0 1];
+
+      case 'S11'
+        plot(nu,real(S11),nu,imag(S11),nu,abs(S11));
+        ylabel('Re({\itS}_{11}),  Im({\itS}_{11}),  |{\itS}_{11}|');
+        ylims = [-1 1];
+        legend('Re({\itS}_{11})','Im({\itS}_{11})','|{\itS}_{11}|','AutoUpdate','off');
+        legend boxoff
+        yline(0)
+
+      case 'returnloss'
+        plot(nu,RL)
+        ylabel('return loss, dB');
+
+      case 'VSWR'
+        semilogy(nu,VSWR);
+        ylabel('VSWR, voltage standing wave ratio');
+        ylims = [1 max(VSWR)];
+        grid on
+    end
+    axis tight
+    if ~isempty(ylims)
+      ylim(ylims)
     end
     xlabel('frequency (GHz)');
-    if ~isempty(beta)
-      title(sprintf('Qu = %d, beta = %g',Qu,beta));
-    else
-      title(sprintf('Q = %d',Q));
-    end
-    ylim([0 1]);
-    line([1 1]*nu0,ylim,'Color','r');
+    xline(nu0,'--','');
+    title(sprintf('{\\nu}_0 = %g GHz, {\\it{Q}}_u = %d, \\beta = %g, {\\it{Q}}_L = %g',nu0,Qu,beta,Qu/(1+beta)));
+
   case 1
-    varargout = {out};
+    varargout = {result};
+
   case 2
-    varargout = {nu,out};
+    varargout = {nu,result};
+end
+
 end

--- a/tests/resonatorprofile_gamma.m
+++ b/tests/resonatorprofile_gamma.m
@@ -1,0 +1,31 @@
+function ok = test(opt)
+
+% Test voltage reflection against expressions from
+%   Vladimir Krymov and Gary Gerfen
+%   Analysis of the tuning and operation of reflection resonator EPR spectrometers
+%   J. Magn. Reson. 162 (2003) 4660478
+%   https://doi.org/10.1016%2FS1090-7807(03)00109-5
+
+% Settings
+nu = linspace(9,10,201);  % GHz
+nu0 = 9.6;  % GHz
+Qu = 200;
+beta = 3.2;
+
+% Expressions from the paper 
+xi = -Qu*(nu/nu0-nu0./nu);  % Eq.(6)
+Gamma = (1-beta-1i*xi)./(1+beta-1i*xi);  % Eq.(7)
+
+Gamma_ = resonatorprofile(nu,nu0,Qu,beta,'voltagereflection');
+
+ok = areequal(Gamma,Gamma_,1e-12,'abs');
+
+if opt.Display
+  plot(nu,real(Gamma),nu,real(Gamma_),'.',nu,imag(Gamma),nu,imag(Gamma_),'.');
+  xlabel('frequency (GHz)');
+  ylabel('Re(\Gamma), Im(\Gamma)');
+  legend('Re(\Gamma) ref','Re(\Gamma)','Im(\Gamma) ref','Im(\Gamma)','AutoUpdate','off');
+  axis tight
+  grid on
+  xline(nu0);
+end

--- a/tests/resonatorprofile_outputs.m
+++ b/tests/resonatorprofile_outputs.m
@@ -1,28 +1,45 @@
 function ok = test()
 
-% Compare resonatorprofile() outputs with mathematical expressions
-nu = linspace(9.2,9.8,101); % GHz
+% Compare resonatorprofile() outputs with the mathematical expressions
+% that are intended to be implemented in the function.
+
+% Settings
+nu = linspace(9,10,1001); % GHz
 nu0 = 9.5; % GHz
-Qu = 2000;
-beta = 1;
+Qu = 200;
+beta = 1.3;
+
+QL = Qu/(1+beta);
+xi = nu/nu0-nu0./nu;
+
+% Reference quantities
+H = 1./(1+1i*QL*xi);
+Gamma = (1-beta+1i*Qu*xi)./(1+beta+1i*Qu*xi);
+Gamma_squared = abs(Gamma).^2;
+S11 = Gamma;
+RL = -20*log10(abs(Gamma));
+VSWR = (1+abs(Gamma))./(1-abs(Gamma));
 
 % Transfer function
-H0 = 1./(1+1i*Qu*(nu/nu0-nu0./nu));
-H = resonatorprofile(nu,nu0,Qu,'transferfunction');
-
-ok(1) = areequal(H0,H,1e-12,'abs');
+H_ = resonatorprofile(nu,nu0,Qu,beta,'transferfunction');
+ok(1) = areequal(H_,H,1e-12,'abs');
 
 % Voltage reflection coefficient
-Gamma0 = (1-beta*H0)./(1+beta*H0);
-Gamma = resonatorprofile(nu,nu0,Qu,beta,'voltagereflection');
+Gamma_ = resonatorprofile(nu,nu0,Qu,beta,'voltagereflection');
+ok(2) = areequal(Gamma_,Gamma,1e-12,'abs');
 
-ok(2) = areequal(Gamma0,Gamma,1e-12,'abs');
+% Power reflection coefficient
+Gamma2_ = resonatorprofile(nu,nu0,Qu,beta,'powerreflection');
+ok(3) = areequal(Gamma2_,Gamma_squared,1e-12,'abs');
 
-% Voltage reflection coefficient
-Prefl0 = abs(Gamma).^2;
-Prefl = resonatorprofile(nu,nu0,Qu,beta,'powerreflection');
+% S11
+S11_ = resonatorprofile(nu,nu0,Qu,beta,'S11');
+ok(4) = areequal(S11_,S11,1e-12,'abs');
 
-ok(3) = areequal(Prefl0,Prefl,1e-12,'abs');
+% Return loss
+RL_ = resonatorprofile(nu,nu0,Qu,beta,'returnloss');
+ok(5) = areequal(RL_,RL,1e-12,'abs');
 
-
-
+% VSWR
+VSWR_ = resonatorprofile(nu,nu0,Qu,beta,'VSWR');
+ok(6) = areequal(VSWR_,VSWR,1e-12,'abs');

--- a/tests/resonatorprofile_powerreflection.m
+++ b/tests/resonatorprofile_powerreflection.m
@@ -1,0 +1,15 @@
+function ok = test()
+
+% Compare resonatorprofile() output with mathematical expression
+
+nu = linspace(9.2,9.8,101); % GHz
+nu0 = 9.5; % GHz
+Qu = 2000;
+beta = 1;
+
+Gamma2 = resonatorprofile(nu,nu0,Qu,beta,'powerreflection');
+
+xi = (nu/nu0-nu0./nu)/2;
+Gamma2_ref = 1 - 4*beta./((1+beta)^2+(2*Qu*xi).^2);
+
+ok = areequal(Gamma2,Gamma2_ref,1e-10,'abs');

--- a/tests/resonatorprofile_syntax.m
+++ b/tests/resonatorprofile_syntax.m
@@ -1,16 +1,22 @@
 function ok = test()
 
 % Syntax test
-nu = linspace(9,10,1001);
-nu0 = 9.6;
+
+% Settings
+nu = linspace(9,10,1001);  % GHz
+nu0 = 9.6;  % GHz
 Qu = 2000;
 beta = 2;
 
+% Missing frequency axis
+H = resonatorprofile([],nu0,Qu,beta,'transferfunction');
+
+% Various output quantities
 H = resonatorprofile(nu,nu0,Qu,beta,'transferfunction');
-H = resonatorprofile(nu,nu0,Qu,'transferfunction');
 G = resonatorprofile(nu,nu0,Qu,beta,'voltagereflection');
-G = resonatorprofile([],nu0,Qu,beta,'voltagereflection');
-P = resonatorprofile(nu,nu0,Qu,beta,'powerreflection');
+G2 = resonatorprofile(nu,nu0,Qu,beta,'powerreflection');
+S11 = resonatorprofile(nu,nu0,Qu,beta,'S11');
+RL = resonatorprofile(nu,nu0,Qu,beta,'returnloss');
+VSWR = resonatorprofile(nu,nu0,Qu,beta,'VSWR');
 
 ok = true;
-

--- a/tests/resonatorprofile_totalpower.m
+++ b/tests/resonatorprofile_totalpower.m
@@ -1,0 +1,14 @@
+function ok = test()
+
+% Make sure that reflected plus transmitted power equals 1.
+
+nu = linspace(9.2,9.8,101); % GHz
+nu0 = 9.5; % GHz
+Qu = 200;
+beta = 1;
+
+P_refl = resonatorprofile(nu,nu0,Qu,beta,'powerreflection');
+P_trans = resonatorprofile(nu,nu0,Qu,beta,'powertransmission');
+P_total = P_refl + P_trans;
+
+ok = areequal(P_total,ones(size(P_total)),1e-15,'abs');


### PR DESCRIPTION
- [x] Implement power transmission coefficient, VSWR, S11 and return loss. This improves connection to terminology used in RF engineering.
- [x] Remove option to provide just QL. QL alone does not determine the power transferred or reflected - both Qu and beta need to be known. For example, (Qu=400, beta=1) and (Qu=800, beta=3) have the same QL of 200, but the former reflects less and transmits more power at resonance,
- [x] Reorganize how quantities are calculated. 
- [x] Add references for mathematical expressions, for internal documentation.
- [x] Improve input argument checking.
- [x] Add more tests. 
