### PR TITLE
Fuzzlevel option for spin-polarized spin systems

### DIFF
--- a/docsrc/pepper.html
+++ b/docsrc/pepper.html
@@ -458,6 +458,7 @@ For isotope mixtures, determines which isotopologues to include in the simulatio
 <div class="optiondescr">
 <p>
 The amount of random noise to add to non-zero Hamiltonian matrix elements to break degeneracies. This is needed in some cases, since EasySpin cannot handle systems with degeneracies in a numerically stable fashion. The default value is 1e-10. This means each non-zero Hamiltonian matrix element is multiplied by a random number between (1-1e-10) and (1+1e-10). This is only used when matrix diagonalization is used.
+If non-equilibrium sublevel populations are provided, FuzzLevel is set to 0 as a default, but can be set to a user-defined non-zero value explicitly.
 </p>
 </div>
 

--- a/docsrc/userguide_pepper.html
+++ b/docsrc/userguide_pepper.html
@@ -585,6 +585,7 @@ All other capabilities of <code>pepper</code> apply equally to frequency sweep a
 
 <p>
 EasySpin is not able to handle systems with degenerate energy levels in an exact fashion when using matrix diagonalization. To make it possible to simulate EPR spectra of such systems, EasySpin automatically adds small random perturbations to non-zero Hamiltonian matrix elements. The level of this added noise can be adjusted in <code>Opt.FuzzLevel</code>. The default value is 1e-10 and should be adequate for most cases.
+The default is instead set to 0 if non-equilibrium spin sublevel populations have been provided, but can be set to any user-defined value if required.
 </p>
 
 <p>

--- a/easyspin/resfields.m
+++ b/easyspin/resfields.m
@@ -153,6 +153,9 @@ end
 
 if ~isfield(Opt,'Sites'), Opt.Sites = []; end
 
+% Determine if non-equilibrium populations need to be computed
+computeNonEquiPops = (isfield(Sys,'initState') && ~isempty(Sys.initState));
+
 % Photoselection
 if ~isfield(Exp,'lightBeam'), Exp.lightBeam = ''; end
 if ~isfield(Exp,'lightScatter'), Exp.lightScatter = 0; end
@@ -215,11 +218,14 @@ DefaultOptions.Transitions = [];  % list of transitions to include
 DefaultOptions.Threshold = 1e-4;  % cutoff threshold for transition pre-selection
 DefaultOptions.Hybrid = 0;
 DefaultOptions.HybridCoreNuclei = [];
+DefaultOptions.FuzzLevel = 1e-10;
+if computeNonEquiPops
+  DefaultOptions.FuzzLevel = 0;
+end
 
 % undocumented fields
 DefaultOptions.TPSGridSize = 4;      % grid size for transition pre-selection
 DefaultOptions.TPSGridSymm = 'D2h';  % grid symmetry for transition pre-selection
-DefaultOptions.FuzzLevel = 1e-10;
 DefaultOptions.Freq2Field = true;
 DefaultOptions.maxSegments = 2000;
 DefaultOptions.ModellingAccuracy = 2e-6;
@@ -409,7 +415,6 @@ nFull = hsdim(Sys);
 nSHFNucStates = nFull/nCore;
 
 % Temperature, non-equilibrium populations
-computeNonEquiPops = (isfield(Sys,'initState') && ~isempty(Sys.initState));
 if computeNonEquiPops
 
   initState = Sys.initState{1};
@@ -458,7 +463,7 @@ end
 % possible degeneracies. Apply if there are more than one electrons or nuclei.
 % This is a very crude workaround to prevent numerical issues due to degeneracies.
 % It probably adds noise in a lot of situations where it is not necessary.
-if Opt.FuzzLevel>0 && ~higherOrder && (CoreSys.nNuclei>1 || CoreSys.nElectrons>1) && ~computeNonEquiPops
+if Opt.FuzzLevel>0 && ~higherOrder && (CoreSys.nNuclei>1 || CoreSys.nElectrons>1)
   noise = 1 + Opt.FuzzLevel*(2*rand(size(kH0))-1);
   noise = (noise+noise.')/2; % make sure it's Hermitian
   kH0 = kH0.*noise;

--- a/easyspin/saffron.m
+++ b/easyspin/saffron.m
@@ -132,7 +132,7 @@ end
 if any(Sys.L(:))
   error('saffron does not support Sys.L.');
 end
-if any(Sys.gStrain) || any(Sys.AStrain) || any(Sys.DStrain)
+if any(Sys.gStrain(:)) || any(Sys.AStrain(:)) || any(Sys.DStrain(:))
   error('saffron does not support Sys.gStrain, Sys.AStrain, or Sys.DStrain.');
 end
 

--- a/tests/pepper_noneqpop_fuzzlevel.m
+++ b/tests/pepper_noneqpop_fuzzlevel.m
@@ -1,0 +1,42 @@
+function ok = test(opt)
+
+% Check FuzzLevel behavior for spin-polarized spin systems
+
+% Spin system
+Sys.S = [1/2 1/2];
+Sys.g = [2.0027; 2.0000];
+Sys.J = -6; % MHz
+
+Sys.Nucs = '1H,1H';
+Sys.A = [0 0 0 5 5 20; 0 0 0 2 2 10]; % MHz
+
+Sys.lwpp = 0.1; % mT
+
+Sys.initState = 'singlet';
+
+% Experimental parameters
+Exp.mwFreq = 9.75; % GHz
+Exp.Range = [346 350]; % mT
+Exp.Harmonic = 0;
+
+% Default options
+[x,spcDefault] = pepper(Sys,Exp);
+
+% Explicitly set Opt.FuzzLevel = 0
+Opt.FuzzLevel = 0;
+[x,spcZeroFuzz] = pepper(Sys,Exp,Opt);
+
+% Check that non-zero FuzzLevel is applied
+Opt.FuzzLevel = 1e-10;
+[x,spcFuzz] = pepper(Sys,Exp,Opt);
+
+if opt.Display
+  plot(x,spcDefault,x,spcZeroFuzz,x,spcFuzz);
+  xlabel('magnetic field [mT]');
+  ylabel('intensity [a.u.]');
+  title('pepper: FuzzLevel for spin-polarized spin systems');
+  legend('default','FuzzLevel = 0','FuzzLevel = 1e-10');
+end
+
+ok(1) = areequal(spcDefault,spcZeroFuzz,1e-12,'abs');
+ok(2) = ~areequal(spcZeroFuzz,spcFuzz,1e-12,'abs');


### PR DESCRIPTION
This PR allows `Opt.FuzzLevel` to be used for spin-polarized spin systems (`Sys.initState` defined), but sets the default to zero. Previously, it was completely disabled for these systems, but in some cases it may be useful for users to enable it explicitly (see forum post [https://easyspin.org/forum/viewtopic.php?t=1398](url)).

A small bug fix for saffron is also included.